### PR TITLE
Use PG_MODULE_MAGIC_EXT in PostgreSQL 18 and later

### DIFF
--- a/src/biscuit.c
+++ b/src/biscuit.c
@@ -83,10 +83,10 @@ typedef struct {
 
 #define BISCUIT_LIBRARY_VERSION "2.2.2"
 
-#if PG_VERSION_NUM >= 180000
-PG_MODULE_MAGIC_EXT(.name = "biscuit", .version = BISCUIT_LIBRARY_VERSION);
+#ifdef PG_MODULE_MAGIC_EXT
+    PG_MODULE_MAGIC_EXT(.name = "biscuit", .version = BISCUIT_LIBRARY_VERSION);
 #else
-PG_MODULE_MAGIC;
+    PG_MODULE_MAGIC;
 #endif
 
 /* Forward declaration of main index structure */

--- a/src/biscuit.c
+++ b/src/biscuit.c
@@ -81,7 +81,13 @@ typedef struct {
     } \
 } while(0)
 
+#define BISCUIT_LIBRARY_VERSION "2.2.2"
+
+#if PG_VERSION_NUM >= 180000
+PG_MODULE_MAGIC_EXT(.name = "biscuit", .version = BISCUIT_LIBRARY_VERSION);
+#else
 PG_MODULE_MAGIC;
+#endif
 
 /* Forward declaration of main index structure */
 typedef struct BiscuitIndex BiscuitIndex;
@@ -110,7 +116,7 @@ PG_FUNCTION_INFO_V1(biscuit_version);
 Datum
 biscuit_version(PG_FUNCTION_ARGS)
 {
-    PG_RETURN_TEXT_P(cstring_to_text("2.2.2"));
+    PG_RETURN_TEXT_P(cstring_to_text(BISCUIT_LIBRARY_VERSION));
 }
 
 // Get build information - Set-Returning Function


### PR DESCRIPTION
The `PG_MODULE_MAGIC_EXT` macro was added in PostgreSQL 18 and makes it possible to see which version of the library is actually loaded using `pg_get_loaded_modules()`.

I picked the name of the define to not clash with the existing `BISCUIT_VERSION`.