### PR TITLE
Release Biscuit 2.3.0 "Bagel": parallel scans, LIKE/ILIKE fixes, and index stability improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Biscuit Index Extension - Changelog
 
+
+## Version 2.3.0 — Bagel
+
+### New Features
+
+* **Parallel index scan support:** Biscuit now integrates with parallel query execution in PostgreSQL, allowing Gather plans to distribute work across workers without duplicate results.
+
+* **Pre-lowercased cache for multi-column indexes:** Added `column_data_cache_lower` to accelerate ILIKE queries by eliminating repeated string normalization during scans.
+
+* **LIKE / ILIKE matching:** Pattern matching now correctly handles `%`, `_`, escape sequences, and complex wildcard combinations.
+
+* **Version updated to `2.3.0 - Bagel`.**
+
+### Bug Fixes
+
+
+* Fixed a crash that could occur when INSERT operations followed SELECT queries on partially loaded indexes.
+
+* Fixed an issue where newly inserted rows could become invisible to subsequent queries due to stale session cache entries.
+
+* Fixed multi-column indexes failing to update length-based bitmap structures during inserts.
+
+* Fixed several memory initialization issues during cache growth that could cause incorrect results or instability.
+
+* Fixed insert operations losing in-memory changes after relcache invalidation.
+
+* Prevented the planner from selecting Biscuit for unqualified scans where no index predicates are present.
+
+* Fixed single-column scans using incorrect query paths for LIKE and ILIKE operations.
+
+
+* Fixed an issue where indexes could remain in a cold state even after background preloading had completed.
+
+* Improved cache update behavior to avoid unnecessary remove-and-reinsert cycles during inserts.
+
+### Performance Improvements
+
+* Eliminated per-row allocations during ILIKE fallback scans by using pre-lowercased caches.
+
+* Simplified TID collection by consolidating scan paths into a single parallel-aware implementation.
+
+### Internal Changes
+
+* Reworked the parallel scan infrastructure around a shared-memory descriptor model and added support for PostgreSQL's parallel index scan callbacks.
+
+* Removed unused LIMIT-tracking logic that was ineffective with the PostgreSQL access method API.
+
+---
+
 ## Version 2.2.3
 
 ### Structural Changes
@@ -17,8 +66,11 @@
   | `biscuit_scan.{c,h}` | Scan lifecycle (beginscan/rescan/gettuple/getbitmap/endscan) |
   | `biscuit_tid.{c,h}` | TID sorting (radix + qsort) and parallel collection |
   | `biscuit_utf8.{c,h}` | UTF-8 character utilities and Datum→text helpers |
+
   All shared types, constants, and macros have been consolidated into
-  `biscuit_common.h`. No SQL-level API changes.
+  `biscuit_common.h`. 
+  
+  No SQL-level API changes.
   
 - **Version bumped to `2.2.3`** (`BISCUIT_LIBRARY_VERSION`).
 

--- a/META.json
+++ b/META.json
@@ -1,17 +1,17 @@
 {
   "name": "biscuit",
-  "abstract": "A bitmap index for wildcard pattern matching",
-  "description": "Biscuit is a fast bitmap-based deterministic pattern matching index access method for PostgreSQL. This release is under active development and may contain bugs.",
-  "version": "2.2.3",
+  "abstract": "A bitmap-based index for wildcard pattern matching",
+  "description": "Biscuit is a bitmap-based index access method for accelerating LIKE and ILIKE pattern matching in PostgreSQL. The project is actively developed and seeking broader testing across diverse workloads.",
+  "version": "2.3.0",
   "maintainer": [
     "Sivaprasad Murali <sivaprasad.off@gmail.com>"
   ],
   "license": "mit",
   "provides": {
     "biscuit": {
-      "file": "sql/biscuit--2.2.3.sql",
+      "file": "sql/biscuit--2.3.0.sql",
       "docfile": "README.md",
-      "version": "2.2.3"
+      "version": "2.3.0"
     }
   },
   "tags": [
@@ -30,7 +30,7 @@
     "access-method",
     "index-access-method"
   ],
-  "release_status": "stable",
+  "release_status": "testing",
   "resources": {
     "homepage": "https://github.com/crystallinecore/biscuit",
     "repository": {

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile for biscuit PostgreSQL extension
 
 EXTENSION = biscuit
-EXTVERSION = 2.2.3
+EXTVERSION = 2.3.0
 
 MODULE_big = biscuit
 
@@ -9,7 +9,9 @@ MODULE_big = biscuit
 OBJS = $(patsubst %.c,%.o,$(wildcard src/*.c))
 
 # Versioned install script (IMPORTANT: must match EXTENSION versioning scheme)
-DATA = sql/biscuit--$(EXTVERSION).sql
+DATA = \
+	sql/biscuit--$(EXTVERSION).sql \
+	sql/biscuit--2.2.3--$(EXTVERSION).sql
 
 PGFILEDESC = "Wildcard pattern matching through bitmap indexing"
 

--- a/README.md
+++ b/README.md
@@ -19,71 +19,51 @@ Although the extension is intended to operate safely and reliably, defects or un
 At this stage, the extension is best suited for evaluation, experimentation, and non-critical workloads. Production deployment should be undertaken only after careful testing and assessment of its suitability for the intended environment.
 
 ---
-## Version - 2.2.3
-
-### Structural Changes
- 
-- **Monolith split into modules.** The single `biscuit.c` file has been
-  decomposed into focused translation units, each with its own header:
-  | Module | Responsibility |
-  |---|---|
-  | `biscuit.c` | AM handler, SQL-callable functions, `_PG_init` |
-  | `biscuit_bitmap.{c,h}` | Roaring bitmap abstraction + fallback bitset |
-  | `biscuit_cache.{c,h}` | Session-scoped index cache |
-  | `biscuit_index.{c,h}` | Index build, load, disk I/O, CRUD helpers |
-  | `biscuit_pattern.{c,h}` | LIKE/ILIKE pattern parsing and bitmap matching |
-  | `biscuit_preload.{c,h}` | Background preload worker and skeleton loader |
-  | `biscuit_scan.{c,h}` | Scan lifecycle (beginscan/rescan/gettuple/getbitmap/endscan) |
-  | `biscuit_tid.{c,h}` | TID sorting (radix + qsort) and parallel collection |
-  | `biscuit_utf8.{c,h}` | UTF-8 character utilities and Datum→text helpers |
-  All shared types, constants, and macros have been consolidated into
-  `biscuit_common.h`. No SQL-level API changes.
-  
-- **Version bumped to `2.2.3`** (`BISCUIT_LIBRARY_VERSION`).
+## Version 2.3.0 — Bagel
 
 ### New Features
 
-- **PostgreSQL 19 Beta 1 support.** `PG_MODULE_MAGIC_EXT` (introduced in PG 19)
-  is now used when available, with a fallback to `PG_MODULE_MAGIC` for older
-  versions. The extension can now be built and loaded against PG 19 development
-  builds without modification.
+* **Parallel index scan support:** Biscuit now integrates with parallel query execution in PostgreSQL, allowing Gather plans to distribute work across workers without duplicate results.
 
+* **Pre-lowercased cache for multi-column indexes:** Added `column_data_cache_lower` to accelerate ILIKE queries by eliminating repeated string normalization during scans.
 
-### Improvements
+* **LIKE / ILIKE matching:** Pattern matching now correctly handles `%`, `_`, escape sequences, and complex wildcard combinations.
 
-- **Memory context correctness.** The session cache (`biscuit_cache.c`) now
-  explicitly switches to `CacheMemoryContext` before allocating cache list
-  nodes, ensuring index structures survive transaction boundaries without
-  relying on caller context. The `biscuit_cleanup_index` stub correctly avoids
-  double-freeing memory owned by the context.
-
-- **`biscuit_complete_preload_local()`** added as a fast in-process upgrade
-  path: rebuilds bitmaps from the already-resident string cache without
-  reopening the relation or re-scanning the heap. Used by `beginscan` when
-  it detects the worker has finished between queries.
-
-- **TID collection refactored into `biscuit_tid.c`.** The unified entry point
-  `biscuit_collect_tids_optimized()` selects parallel vs. single-threaded
-  collection automatically and supports an optional `limit_hint` to avoid
-  collecting more TIDs than the executor needs.
-
-- **Fallback scan in `biscuit_preload.c`** supports NOT LIKE and NOT ILIKE
-  during warm-up via a hash-map TID→record-index lookup, maintaining correct
-  inversion semantics without bitmaps.
-
-- **UTF-8 helpers isolated in `biscuit_utf8.{c,h}`**, removing scattered
-  inline character-length and lowercase conversion code from the pattern and
-  index modules.
-
-- **`biscuit_columnindex_memory_usage()`** now validates `max_length >= 0`
-  before iterating length bitmap arrays and emits a `WARNING` on corrupt
-  state rather than reading out-of-bounds.
+* **Version updated to `2.3.0 - Bagel`.**
 
 ### Bug Fixes
 
-- `biscuit_cache_remove()` no longer calls `pfree` on list nodes; they are
-  owned by `CacheMemoryContext` and must not be freed manually.
 
+* Fixed a crash that could occur when INSERT operations followed SELECT queries on partially loaded indexes.
+
+* Fixed an issue where newly inserted rows could become invisible to subsequent queries due to stale session cache entries.
+
+* Fixed multi-column indexes failing to update length-based bitmap structures during inserts.
+
+* Fixed several memory initialization issues during cache growth that could cause incorrect results or instability.
+
+* Fixed insert operations losing in-memory changes after relcache invalidation.
+
+* Prevented the planner from selecting Biscuit for unqualified scans where no index predicates are present.
+
+* Fixed single-column scans using incorrect query paths for LIKE and ILIKE operations.
+
+
+* Fixed an issue where indexes could remain in a cold state even after background preloading had completed.
+
+* Improved cache update behavior to avoid unnecessary remove-and-reinsert cycles during inserts.
+
+### Performance Improvements
+
+* Eliminated per-row allocations during ILIKE fallback scans by using pre-lowercased caches.
+
+* Simplified TID collection by consolidating scan paths into a single parallel-aware implementation.
+
+### Internal Changes
+
+* Reworked the parallel scan infrastructure around a shared-memory descriptor model and added support for PostgreSQL's parallel index scan callbacks.
+
+* Removed unused LIMIT-tracking logic that was ineffective with the PostgreSQL access method API.
 
 ---
 

--- a/biscuit.control
+++ b/biscuit.control
@@ -1,8 +1,8 @@
 # biscuit.control
 # Control file for PostgreSQL Biscuit extension
 
-default_version = '2.2.3'
-comment = 'Bitmap-based index access method for fast pattern matching (LIKE/ILIKE), union/intersection queries, and multi-column indexing.'
+default_version = '2.3.0'
+comment = 'Bitmap-based index access method for fast pattern matching (LIKE/ILIKE).'
 
 module_pathname = '$libdir/biscuit'
 

--- a/sql/biscuit--2.2.3--2.3.0.sql
+++ b/sql/biscuit--2.2.3--2.3.0.sql
@@ -1,0 +1,4 @@
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION biscuit UPDATE TO '2.3.0'" to load this file. \quit
+
+-- No SQL changes in 2.3.0.

--- a/src/biscuit.c
+++ b/src/biscuit.c
@@ -26,6 +26,7 @@
 #include "biscuit_index.h"
 #include "biscuit_scan.h"
 #include "biscuit_preload.h"
+#include "biscuit_tid.h"
 
 /* ================================================================
  * MODULE MAGIC

--- a/src/biscuit.c
+++ b/src/biscuit.c
@@ -240,9 +240,9 @@ biscuit_handler(PG_FUNCTION_ARGS)
     amroutine->amendscan             = biscuit_endscan;
     amroutine->ammarkpos             = NULL;
     amroutine->amrestrpos            = NULL;
-    amroutine->amestimateparallelscan = NULL;
-    amroutine->aminitparallelscan    = NULL;
-    amroutine->amparallelrescan      = NULL;
+    amroutine->amestimateparallelscan = biscuit_estimateparallelscan;
+    amroutine->aminitparallelscan    = biscuit_initparallelscan;
+    amroutine->amparallelrescan      = biscuit_parallelrescan;
 
     PG_RETURN_POINTER(amroutine);
 }

--- a/src/biscuit_cache.c
+++ b/src/biscuit_cache.c
@@ -51,9 +51,24 @@ biscuit_cache_insert(Oid indexoid, BiscuitIndex *idx)
     BiscuitIndexCacheEntry *entry;
     MemoryContext            oldcontext;
 
-    /* Remove any stale entry first */
-    biscuit_cache_remove(indexoid);
+    /*
+     * Fast path: an entry for this indexoid already exists.  Callers
+     * (e.g. biscuit_insert) call this once per tuple to make sure the
+     * global cache reflects the latest mutated BiscuitIndex, even though
+     * the pointer itself usually hasn't changed within a statement.
+     * Updating the existing node in place avoids a palloc + remove/insert
+     * cycle (and the associated DEBUG1 log spam) for every single row.
+     */
+    for (entry = biscuit_cache_head; entry != NULL; entry = entry->next)
+    {
+        if (entry->indexoid == indexoid)
+        {
+            entry->index = idx;
+            return;
+        }
+    }
 
+    /* No existing entry: allocate a new node in CacheMemoryContext */
     oldcontext = MemoryContextSwitchTo(CacheMemoryContext);
 
     entry            = (BiscuitIndexCacheEntry *) palloc(sizeof(BiscuitIndexCacheEntry));

--- a/src/biscuit_common.h
+++ b/src/biscuit_common.h
@@ -79,7 +79,7 @@ typedef struct {
 #define CHAR_RANGE                      256
 #define TOMBSTONE_CLEANUP_THRESHOLD     1000
 #define RADIX_SORT_THRESHOLD            5000
-#define BISCUIT_LIBRARY_VERSION         "2.2.4 - Petroleum"
+#define BISCUIT_LIBRARY_VERSION         "2.2.4 - Bagel"
 
 /* ==================== MEMORY MANAGEMENT MACROS ==================== */
 

--- a/src/biscuit_common.h
+++ b/src/biscuit_common.h
@@ -41,6 +41,7 @@
 #include "storage/dsm.h"
 #include "storage/shm_toc.h"
 #include "port/atomics.h"
+#include "nodes/execnodes.h"
 
 /* ==================== ROARING BITMAP TYPES ==================== */
 
@@ -78,7 +79,7 @@ typedef struct {
 #define CHAR_RANGE                      256
 #define TOMBSTONE_CLEANUP_THRESHOLD     1000
 #define RADIX_SORT_THRESHOLD            5000
-#define BISCUIT_LIBRARY_VERSION         "2.2.4 - Halwa"
+#define BISCUIT_LIBRARY_VERSION         "2.2.4 - Parallelised"
 
 /* ==================== MEMORY MANAGEMENT MACROS ==================== */
 

--- a/src/biscuit_common.h
+++ b/src/biscuit_common.h
@@ -78,7 +78,7 @@ typedef struct {
 #define CHAR_RANGE                      256
 #define TOMBSTONE_CLEANUP_THRESHOLD     1000
 #define RADIX_SORT_THRESHOLD            5000
-#define BISCUIT_LIBRARY_VERSION         "2.2.4 - Pickle"
+#define BISCUIT_LIBRARY_VERSION         "2.2.4 - Halwa"
 
 /* ==================== MEMORY MANAGEMENT MACROS ==================== */
 

--- a/src/biscuit_common.h
+++ b/src/biscuit_common.h
@@ -79,7 +79,7 @@ typedef struct {
 #define CHAR_RANGE                      256
 #define TOMBSTONE_CLEANUP_THRESHOLD     1000
 #define RADIX_SORT_THRESHOLD            5000
-#define BISCUIT_LIBRARY_VERSION         "2.2.4 - Bagel"
+#define BISCUIT_LIBRARY_VERSION         "2.2.4 - Petroleum"
 
 /* ==================== MEMORY MANAGEMENT MACROS ==================== */
 

--- a/src/biscuit_common.h
+++ b/src/biscuit_common.h
@@ -79,7 +79,7 @@ typedef struct {
 #define CHAR_RANGE                      256
 #define TOMBSTONE_CLEANUP_THRESHOLD     1000
 #define RADIX_SORT_THRESHOLD            5000
-#define BISCUIT_LIBRARY_VERSION         "2.3.0 - Pyramid"
+#define BISCUIT_LIBRARY_VERSION         "2.3.0 - Bagel"
 
 /* ==================== MEMORY MANAGEMENT MACROS ==================== */
 

--- a/src/biscuit_common.h
+++ b/src/biscuit_common.h
@@ -37,6 +37,10 @@
 #include "utils/pg_locale.h"
 #include "mb/pg_wchar.h"
 #include "storage/itemptr.h"
+#include "access/parallel.h"
+#include "storage/dsm.h"
+#include "storage/shm_toc.h"
+#include "port/atomics.h"
 
 /* ==================== ROARING BITMAP TYPES ==================== */
 
@@ -74,7 +78,7 @@ typedef struct {
 #define CHAR_RANGE                      256
 #define TOMBSTONE_CLEANUP_THRESHOLD     1000
 #define RADIX_SORT_THRESHOLD            5000
-#define BISCUIT_LIBRARY_VERSION         "2.2.3 - Wafer"
+#define BISCUIT_LIBRARY_VERSION         "2.2.4 - Pickle"
 
 /* ==================== MEMORY MANAGEMENT MACROS ==================== */
 

--- a/src/biscuit_common.h
+++ b/src/biscuit_common.h
@@ -79,7 +79,7 @@ typedef struct {
 #define CHAR_RANGE                      256
 #define TOMBSTONE_CLEANUP_THRESHOLD     1000
 #define RADIX_SORT_THRESHOLD            5000
-#define BISCUIT_LIBRARY_VERSION         "2.3.0 - Bagel"
+#define BISCUIT_LIBRARY_VERSION         "2.3.0 - Pyramid"
 
 /* ==================== MEMORY MANAGEMENT MACROS ==================== */
 

--- a/src/biscuit_common.h
+++ b/src/biscuit_common.h
@@ -79,7 +79,7 @@ typedef struct {
 #define CHAR_RANGE                      256
 #define TOMBSTONE_CLEANUP_THRESHOLD     1000
 #define RADIX_SORT_THRESHOLD            5000
-#define BISCUIT_LIBRARY_VERSION         "2.2.4 - Bagel"
+#define BISCUIT_LIBRARY_VERSION         "2.3.0 - Croissant"
 
 /* ==================== MEMORY MANAGEMENT MACROS ==================== */
 
@@ -150,6 +150,24 @@ typedef struct BiscuitIndex {
 
     /* Per-column indices for multi-column indexes */
     ColumnIndex *column_indices;
+
+    /*
+     * Pre-lowercased string cache for multi-column indexes.
+     * column_data_cache_lower[col][rec] mirrors column_data_cache[col][rec]
+     * but with every string run through biscuit_str_tolower() at build /
+     * load time.  This lets biscuit_fallback_scan() use a direct pointer
+     * for ILIKE queries instead of allocating a new lowercased copy on
+     * every record on every scan call.
+     *
+     * Layout and lifecycle are identical to column_data_cache:
+     *   • Allocated as char**  per column, palloc0'd to idx->capacity slots.
+     *   • Grown with repalloc whenever column_data_cache is grown.
+     *   • NULL entries mirror NULL entries in column_data_cache.
+     *   • Freed / NULLed in the vacuum bulkdelete path alongside
+     *     column_data_cache entries.
+     * Only allocated when num_columns > 1; NULL otherwise.
+     */
+    char ***column_data_cache_lower;
 
     /* Single-column (legacy) fields */
     CharIndex pos_idx_legacy[CHAR_RANGE];

--- a/src/biscuit_common.h
+++ b/src/biscuit_common.h
@@ -79,7 +79,7 @@ typedef struct {
 #define CHAR_RANGE                      256
 #define TOMBSTONE_CLEANUP_THRESHOLD     1000
 #define RADIX_SORT_THRESHOLD            5000
-#define BISCUIT_LIBRARY_VERSION         "2.2.4 - Parallelised"
+#define BISCUIT_LIBRARY_VERSION         "2.2.4 - Bagel"
 
 /* ==================== MEMORY MANAGEMENT MACROS ==================== */
 

--- a/src/biscuit_common.h
+++ b/src/biscuit_common.h
@@ -79,7 +79,7 @@ typedef struct {
 #define CHAR_RANGE                      256
 #define TOMBSTONE_CLEANUP_THRESHOLD     1000
 #define RADIX_SORT_THRESHOLD            5000
-#define BISCUIT_LIBRARY_VERSION         "2.3.0 - Croissant"
+#define BISCUIT_LIBRARY_VERSION         "2.3.0 - Bagel"
 
 /* ==================== MEMORY MANAGEMENT MACROS ==================== */
 

--- a/src/biscuit_index.c
+++ b/src/biscuit_index.c
@@ -1253,6 +1253,101 @@ biscuit_insert(Relation index,
                     idx->column_data_cache_lower[col][slot] = biscuit_str_tolower(str, out_len);
 
                 biscuit_index_column_record(idx, col, str, out_len, slot);
+
+                /*
+                 * FIX 5 — multi-column length bitmaps never updated on insert.
+                 *
+                 * biscuit_index_column_record() only maintains the per-character
+                 * position/negative-position bitmaps and char_cache for this
+                 * column's ColumnIndex.  It does NOT touch cidx->length_bitmaps /
+                 * cidx->length_ge_bitmaps (or the _lower variants), which were
+                 * only ever populated in the bulk-build pass (biscuit_build).
+                 *
+                 * Because biscuit_insert never resets idx->preload_state after
+                 * mutating idx, preload_state stays BISCUIT_PRELOAD_DONE across
+                 * the insert.  biscuit_rescan() trusts that flag and goes
+                 * straight to the bitmap fast path (biscuit_rescan_multicolumn),
+                 * which consults these length bitmaps for length-based
+                 * predicates. Newly inserted rows were invisible there even
+                 * though column_data_cache, char_cache, and the position
+                 * bitmaps were all correctly updated above — hence "insert is
+                 * on disk and in data_cache, but warm queries don't see it".
+                 *
+                 * Mirror the legacy single-column growth/insert logic here,
+                 * operating on this column's ColumnIndex (cidx) instead of
+                 * the top-level idx fields.
+                 */
+                {
+                    ColumnIndex *cidx = &idx->column_indices[col];
+                    int          cl   = biscuit_utf8_char_count(str, out_len);
+
+                    if (cl >= cidx->max_length)
+                    {
+                        int old_ml = cidx->max_length;
+                        int new_ml = (cl + 1) * 2;
+
+                        if (cidx->length_bitmaps)
+                            cidx->length_bitmaps    = (RoaringBitmap **) repalloc(cidx->length_bitmaps,    new_ml * sizeof(RoaringBitmap *));
+                        else
+                            cidx->length_bitmaps    = (RoaringBitmap **) palloc0(new_ml * sizeof(RoaringBitmap *));
+
+                        if (cidx->length_ge_bitmaps)
+                            cidx->length_ge_bitmaps = (RoaringBitmap **) repalloc(cidx->length_ge_bitmaps, new_ml * sizeof(RoaringBitmap *));
+                        else
+                            cidx->length_ge_bitmaps = (RoaringBitmap **) palloc0(new_ml * sizeof(RoaringBitmap *));
+
+                        for (int i = old_ml; i < new_ml; i++)
+                        {
+                            cidx->length_bitmaps[i]    = NULL;
+                            cidx->length_ge_bitmaps[i] = biscuit_roaring_create();
+                        }
+                        cidx->max_length = new_ml;
+                    }
+                    if (!cidx->length_bitmaps[cl])
+                        cidx->length_bitmaps[cl] = biscuit_roaring_create();
+                    biscuit_roaring_add(cidx->length_bitmaps[cl], slot);
+                    for (int i = 0; i <= cl && i < cidx->max_length; i++)
+                        biscuit_roaring_add(cidx->length_ge_bitmaps[i], slot);
+
+                    /* Lowercase length bitmaps */
+                    if (idx->column_data_cache_lower)
+                    {
+                        const char *lstr = idx->column_data_cache_lower[col][slot];
+                        if (lstr)
+                        {
+                            int lbl = strlen(lstr);
+                            int lcl = biscuit_utf8_char_count(lstr, lbl);
+
+                            if (lcl >= cidx->max_length_lower)
+                            {
+                                int old_ml = cidx->max_length_lower;
+                                int new_ml = (lcl + 1) * 2;
+
+                                if (cidx->length_bitmaps_lower)
+                                    cidx->length_bitmaps_lower    = (RoaringBitmap **) repalloc(cidx->length_bitmaps_lower,    new_ml * sizeof(RoaringBitmap *));
+                                else
+                                    cidx->length_bitmaps_lower    = (RoaringBitmap **) palloc0(new_ml * sizeof(RoaringBitmap *));
+
+                                if (cidx->length_ge_bitmaps_lower)
+                                    cidx->length_ge_bitmaps_lower = (RoaringBitmap **) repalloc(cidx->length_ge_bitmaps_lower, new_ml * sizeof(RoaringBitmap *));
+                                else
+                                    cidx->length_ge_bitmaps_lower = (RoaringBitmap **) palloc0(new_ml * sizeof(RoaringBitmap *));
+
+                                for (int i = old_ml; i < new_ml; i++)
+                                {
+                                    cidx->length_bitmaps_lower[i]    = NULL;
+                                    cidx->length_ge_bitmaps_lower[i] = biscuit_roaring_create();
+                                }
+                                cidx->max_length_lower = new_ml;
+                            }
+                            if (!cidx->length_bitmaps_lower[lcl])
+                                cidx->length_bitmaps_lower[lcl] = biscuit_roaring_create();
+                            biscuit_roaring_add(cidx->length_bitmaps_lower[lcl], slot);
+                            for (int i = 0; i <= lcl && i < cidx->max_length_lower; i++)
+                                biscuit_roaring_add(cidx->length_ge_bitmaps_lower[i], slot);
+                        }
+                    }
+                } /* end multi-column length-bitmap block */
             }
             else
             {

--- a/src/biscuit_index.c
+++ b/src/biscuit_index.c
@@ -932,10 +932,6 @@ biscuit_load_index(Relation index)
     return (BiscuitIndex *) index->rd_amcache;
 }
 
-/* ================================================================
- * SECTION 4 – INSERT
- * ================================================================ */
-
 bool
 biscuit_insert(Relation index,
                Datum *values,
@@ -1012,17 +1008,44 @@ biscuit_insert(Relation index,
         /* Append new slot */
         if (idx->num_records >= idx->capacity)
         {
+            int old_capacity = idx->capacity;
             idx->capacity *= 2;
             idx->tids = (ItemPointerData *) repalloc(idx->tids, idx->capacity * sizeof(ItemPointerData));
             if (idx->num_columns == 1)
             {
                 idx->data_cache       = (char **) repalloc(idx->data_cache,       idx->capacity * sizeof(char *));
                 idx->data_cache_lower = (char **) repalloc(idx->data_cache_lower, idx->capacity * sizeof(char *));
+                /*
+                 * FIX A: Zero-initialise the newly allocated tail so that
+                 * data_cache[slot] and data_cache_lower[slot] are reliably
+                 * NULL for fresh slots.  Without this, repalloc leaves the
+                 * memory uninitialised; the guard at "if (idx->data_cache_lower[slot])"
+                 * below may pass on garbage and strlen/utf8_char_count then
+                 * dereferences a wild pointer, producing the segfault at
+                 * address 0xfffffffffffffff8 (-8).
+                 */
+                memset(idx->data_cache       + old_capacity, 0,
+                       (idx->capacity - old_capacity) * sizeof(char *));
+                memset(idx->data_cache_lower  + old_capacity, 0,
+                       (idx->capacity - old_capacity) * sizeof(char *));
             }
             else
             {
                 for (col = 0; col < idx->num_columns; col++)
-                    idx->column_data_cache[col] = (char **) repalloc(idx->column_data_cache[col], idx->capacity * sizeof(char *));
+                {
+                    int old_cap = old_capacity; /* captured before the loop */
+                    idx->column_data_cache[col] = (char **) repalloc(
+                        idx->column_data_cache[col], idx->capacity * sizeof(char *));
+                    /*
+                     * FIX B: Same zero-init requirement for the multi-column
+                     * cache arrays.  biscuit_bulkdelete reads column_data_cache[0][i]
+                     * to detect live records; uninitialised bytes here cause it to
+                     * treat garbage as a valid pointer and skip or misclassify rows,
+                     * and the subsequent andnot/remove passes then touch freed memory.
+                     */
+                    memset(idx->column_data_cache[col] + old_cap, 0,
+                           (idx->capacity - old_cap) * sizeof(char *));
+                }
             }
         }
         slot = idx->num_records++;
@@ -1040,38 +1063,49 @@ biscuit_insert(Relation index,
             int   byte_len = VARSIZE_ANY_EXHDR(txt);
 
             idx->data_cache[slot] = pnstrdup(str, byte_len);
+
+            /*
+             * biscuit_index_single_record writes idx->data_cache_lower[slot]
+             * as a side-effect (line ~318).  It must run BEFORE the length-
+             * bitmap block below reads data_cache_lower[slot].
+             */
             biscuit_index_single_record(idx, str, byte_len, slot);
 
             /* Grow length bitmaps if needed */
             {
-            int cl  = biscuit_utf8_char_count(str, byte_len);
+            int cl = biscuit_utf8_char_count(str, byte_len);
             if (cl >= idx->max_length_legacy)
             {
-                int old = idx->max_length_legacy;
-                int new = (cl + 1) * 2;
-                idx->length_bitmaps_legacy    = (RoaringBitmap **) repalloc(idx->length_bitmaps_legacy,    new * sizeof(RoaringBitmap *));
-                idx->length_ge_bitmaps_legacy = (RoaringBitmap **) repalloc(idx->length_ge_bitmaps_legacy, new * sizeof(RoaringBitmap *));
-                for (int i = old; i < new; i++) { idx->length_bitmaps_legacy[i] = NULL; idx->length_ge_bitmaps_legacy[i] = biscuit_roaring_create(); }
-                idx->max_length_legacy = new;
+                int old_ml = idx->max_length_legacy;
+                int new_ml = (cl + 1) * 2;
+                idx->length_bitmaps_legacy    = (RoaringBitmap **) repalloc(idx->length_bitmaps_legacy,    new_ml * sizeof(RoaringBitmap *));
+                idx->length_ge_bitmaps_legacy = (RoaringBitmap **) repalloc(idx->length_ge_bitmaps_legacy, new_ml * sizeof(RoaringBitmap *));
+                for (int i = old_ml; i < new_ml; i++) { idx->length_bitmaps_legacy[i] = NULL; idx->length_ge_bitmaps_legacy[i] = biscuit_roaring_create(); }
+                idx->max_length_legacy = new_ml;
             }
             if (!idx->length_bitmaps_legacy[cl]) idx->length_bitmaps_legacy[cl] = biscuit_roaring_create();
             biscuit_roaring_add(idx->length_bitmaps_legacy[cl], slot);
             for (int i = 0; i <= cl && i < idx->max_length_legacy; i++)
                 biscuit_roaring_add(idx->length_ge_bitmaps_legacy[i], slot);
 
-            /* Lowercase length bitmaps */
+            /*
+             * Lowercase length bitmaps.
+             * data_cache_lower[slot] was populated by biscuit_index_single_record
+             * above; for a NULL-valued column this slot was zeroed by FIX A so
+             * the guard below is now always reliable.
+             */
             if (idx->data_cache_lower[slot])
             {
                 int lbl = strlen(idx->data_cache_lower[slot]);
                 int lcl = biscuit_utf8_char_count(idx->data_cache_lower[slot], lbl);
                 if (lcl >= idx->max_length_lower)
                 {
-                    int old = idx->max_length_lower;
-                    int new = (lcl + 1) * 2;
-                    idx->length_bitmaps_lower    = (RoaringBitmap **) repalloc(idx->length_bitmaps_lower,    new * sizeof(RoaringBitmap *));
-                    idx->length_ge_bitmaps_lower = (RoaringBitmap **) repalloc(idx->length_ge_bitmaps_lower, new * sizeof(RoaringBitmap *));
-                    for (int i = old; i < new; i++) { idx->length_bitmaps_lower[i] = NULL; idx->length_ge_bitmaps_lower[i] = biscuit_roaring_create(); }
-                    idx->max_length_lower = new;
+                    int old_ml = idx->max_length_lower;
+                    int new_ml = (lcl + 1) * 2;
+                    idx->length_bitmaps_lower    = (RoaringBitmap **) repalloc(idx->length_bitmaps_lower,    new_ml * sizeof(RoaringBitmap *));
+                    idx->length_ge_bitmaps_lower = (RoaringBitmap **) repalloc(idx->length_ge_bitmaps_lower, new_ml * sizeof(RoaringBitmap *));
+                    for (int i = old_ml; i < new_ml; i++) { idx->length_bitmaps_lower[i] = NULL; idx->length_ge_bitmaps_lower[i] = biscuit_roaring_create(); }
+                    idx->max_length_lower = new_ml;
                 }
                 if (!idx->length_bitmaps_lower[lcl]) idx->length_bitmaps_lower[lcl] = biscuit_roaring_create();
                 biscuit_roaring_add(idx->length_bitmaps_lower[lcl], slot);
@@ -1097,11 +1131,8 @@ biscuit_insert(Relation index,
                 idx->column_data_cache[col][slot] = str;
 
                 /*
-                 * FIX 3: The call below was previously missing ("omitted for brevity"),
-                 * causing every row inserted after index build to be silently absent
-                 * from all character/position/length bitmaps.  Subsequent queries
-                 * would return stale TIDs and could segfault when dereferencing
-                 * length_bitmaps for an unindexed slot.
+                 * FIX 3 (pre-existing): call was previously missing, causing
+                 * every post-build insert to be absent from all bitmaps.
                  */
                 biscuit_index_column_record(idx, col, str, out_len, slot);
             }
@@ -1352,13 +1383,27 @@ biscuit_costestimate(PlannerInfo *root, IndexPath *path,
         index_close(index, AccessShareLock);
     }
 
+    if (path->indexclauses == NIL)
+    {
+        /*
+         * No usable quals (e.g. plain SELECT * with no WHERE). Make this
+         * path unattractive so the planner falls back to a seqscan instead
+         * of using Biscuit with zero scan keys, which would return 0 rows.
+         */
+        *indexStartupCost = 1.0e10;
+        *indexTotalCost   = 1.0e10;
+        *indexSelectivity = 1.0;
+        *indexCorrelation = 0.0;
+        if (indexPages) *indexPages = numPages;
+        return;
+    }
+
     *indexStartupCost  = 0.0;
     *indexTotalCost    = 0.01 + (numPages * random_page_cost);
     *indexSelectivity  = 0.01;
     *indexCorrelation  = 1.0;
     if (indexPages) *indexPages = numPages;
 }
-
 bytea *
 biscuit_options(Datum reloptions, bool validate)
 {

--- a/src/biscuit_index.c
+++ b/src/biscuit_index.c
@@ -23,7 +23,16 @@ biscuit_write_metadata_to_disk(Relation index, BiscuitIndex *idx)
     GenericXLogState  *state;
     BiscuitMetaPageData *meta;
 
-    buf   = ReadBufferExtended(index, MAIN_FORKNUM, P_NEW, RBM_NORMAL, NULL);
+    //buf   = ReadBufferExtended(index, MAIN_FORKNUM, P_NEW, RBM_NORMAL, NULL);
+    
+    {
+        BlockNumber nblocks = RelationGetNumberOfBlocks(index);
+        if (nblocks == 0)
+            buf = ReadBufferExtended(index, MAIN_FORKNUM, P_NEW, RBM_NORMAL, NULL);
+        else
+            buf = ReadBuffer(index, BISCUIT_METAPAGE_BLKNO);
+    }
+    
     LockBuffer(buf, BUFFER_LOCK_EXCLUSIVE);
 
     state = GenericXLogStart(index);
@@ -957,9 +966,41 @@ biscuit_insert(Relation index,
     idx = (BiscuitIndex *) index->rd_amcache;
     if (!idx)
     {
-        idx = biscuit_load_index(index);
+        /*
+         * rd_amcache was cleared by a relcache invalidation (PostgreSQL does
+         * this on any catalog access, including those triggered by INSERT's
+         * executor setup).  Check the global biscuit_cache first — it holds
+         * the live, already-mutated index built during a preceding scan or
+         * insert — before falling back to a full heap re-scan which would
+         * lose all in-flight inserts.
+         */
+        idx = biscuit_cache_lookup(RelationGetRelid(index));
+        if (!idx)
+            idx = biscuit_load_index(index);
         index->rd_amcache = idx;
     }
+
+    /*
+     * FIX 1 — SELECT → INSERT crash (segfault at 0xfffffffffffffff8).
+     *
+     * When a SELECT runs before any INSERT, beginscan calls
+     * biscuit_load_skeleton() which leaves all four length-bitmap arrays
+     * (length_bitmaps_legacy, length_ge_bitmaps_legacy, length_bitmaps_lower,
+     * length_ge_bitmaps_lower) as NULL and max_length_legacy / max_length_lower
+     * as 0.  The grow-path below then calls repalloc(NULL, ...) which reads
+     * the palloc chunk header at ptr-8 == 0xfffffffffffffff8 and crashes.
+     *
+     * Fix: if the index arrived as a skeleton (preload_state < DONE), complete
+     * the bitmap build inline now, before touching any length-bitmap pointer.
+     * biscuit_complete_preload_local() is idempotent and cheap when
+     * num_records is small; for large indexes this path is only hit once per
+     * session because the result is stored back into the cache below.
+     *
+     * This also fixes the mirrored hazard in the multi-column path where
+     * cidx->length_bitmaps / length_ge_bitmaps are NULL in a skeleton.
+     */
+    if (idx->preload_state < BISCUIT_PRELOAD_DONE)
+        biscuit_complete_preload_local(idx, RelationGetRelid(index));
 
     oldcontext = MemoryContextSwitchTo(CacheMemoryContext);
 
@@ -976,13 +1017,14 @@ biscuit_insert(Relation index,
 
             if (idx->num_columns == 1)
             {
-                if (idx->data_cache[slot])      { pfree(idx->data_cache[slot]);      idx->data_cache[slot]      = NULL; }
-                if (idx->data_cache_lower[slot]) { pfree(idx->data_cache_lower[slot]); idx->data_cache_lower[slot] = NULL; }
+                if (idx->data_cache[slot])       { pfree(idx->data_cache[slot]);       idx->data_cache[slot]       = NULL; }
+                if (idx->data_cache_lower[slot])  { pfree(idx->data_cache_lower[slot]); idx->data_cache_lower[slot] = NULL; }
             }
             else
             {
                 for (col = 0; col < idx->num_columns; col++)
-                    if (idx->column_data_cache[col][slot]) { pfree(idx->column_data_cache[col][slot]); idx->column_data_cache[col][slot] = NULL; }
+                    if (idx->column_data_cache[col][slot])
+                        { pfree(idx->column_data_cache[col][slot]); idx->column_data_cache[col][slot] = NULL; }
             }
 
             /* Un-tombstone if needed */
@@ -1021,8 +1063,7 @@ biscuit_insert(Relation index,
                  * NULL for fresh slots.  Without this, repalloc leaves the
                  * memory uninitialised; the guard at "if (idx->data_cache_lower[slot])"
                  * below may pass on garbage and strlen/utf8_char_count then
-                 * dereferences a wild pointer, producing the segfault at
-                 * address 0xfffffffffffffff8 (-8).
+                 * dereferences a wild pointer.
                  */
                 memset(idx->data_cache       + old_capacity, 0,
                        (idx->capacity - old_capacity) * sizeof(char *));
@@ -1033,15 +1074,14 @@ biscuit_insert(Relation index,
             {
                 for (col = 0; col < idx->num_columns; col++)
                 {
-                    int old_cap = old_capacity; /* captured before the loop */
+                    int old_cap = old_capacity;
                     idx->column_data_cache[col] = (char **) repalloc(
                         idx->column_data_cache[col], idx->capacity * sizeof(char *));
                     /*
                      * FIX B: Same zero-init requirement for the multi-column
                      * cache arrays.  biscuit_bulkdelete reads column_data_cache[0][i]
                      * to detect live records; uninitialised bytes here cause it to
-                     * treat garbage as a valid pointer and skip or misclassify rows,
-                     * and the subsequent andnot/remove passes then touch freed memory.
+                     * treat garbage as a valid pointer and misclassify rows.
                      */
                     memset(idx->column_data_cache[col] + old_cap, 0,
                            (idx->capacity - old_cap) * sizeof(char *));
@@ -1058,60 +1098,93 @@ biscuit_insert(Relation index,
     {
         if (!isnull[0])
         {
-            text *txt     = DatumGetTextPP(values[0]);
-            char *str     = VARDATA_ANY(txt);
+            text *txt      = DatumGetTextPP(values[0]);
+            char *str      = VARDATA_ANY(txt);
             int   byte_len = VARSIZE_ANY_EXHDR(txt);
 
             idx->data_cache[slot] = pnstrdup(str, byte_len);
 
             /*
              * biscuit_index_single_record writes idx->data_cache_lower[slot]
-             * as a side-effect (line ~318).  It must run BEFORE the length-
-             * bitmap block below reads data_cache_lower[slot].
+             * as a side-effect.  It must run BEFORE the length-bitmap block
+             * below reads data_cache_lower[slot].
              */
             biscuit_index_single_record(idx, str, byte_len, slot);
 
             /* Grow length bitmaps if needed */
             {
-            int cl = biscuit_utf8_char_count(str, byte_len);
-            if (cl >= idx->max_length_legacy)
-            {
-                int old_ml = idx->max_length_legacy;
-                int new_ml = (cl + 1) * 2;
-                idx->length_bitmaps_legacy    = (RoaringBitmap **) repalloc(idx->length_bitmaps_legacy,    new_ml * sizeof(RoaringBitmap *));
-                idx->length_ge_bitmaps_legacy = (RoaringBitmap **) repalloc(idx->length_ge_bitmaps_legacy, new_ml * sizeof(RoaringBitmap *));
-                for (int i = old_ml; i < new_ml; i++) { idx->length_bitmaps_legacy[i] = NULL; idx->length_ge_bitmaps_legacy[i] = biscuit_roaring_create(); }
-                idx->max_length_legacy = new_ml;
-            }
-            if (!idx->length_bitmaps_legacy[cl]) idx->length_bitmaps_legacy[cl] = biscuit_roaring_create();
-            biscuit_roaring_add(idx->length_bitmaps_legacy[cl], slot);
-            for (int i = 0; i <= cl && i < idx->max_length_legacy; i++)
-                biscuit_roaring_add(idx->length_ge_bitmaps_legacy[i], slot);
-
-            /*
-             * Lowercase length bitmaps.
-             * data_cache_lower[slot] was populated by biscuit_index_single_record
-             * above; for a NULL-valued column this slot was zeroed by FIX A so
-             * the guard below is now always reliable.
-             */
-            if (idx->data_cache_lower[slot])
-            {
-                int lbl = strlen(idx->data_cache_lower[slot]);
-                int lcl = biscuit_utf8_char_count(idx->data_cache_lower[slot], lbl);
-                if (lcl >= idx->max_length_lower)
+                int cl = biscuit_utf8_char_count(str, byte_len);
+                if (cl >= idx->max_length_legacy)
                 {
-                    int old_ml = idx->max_length_lower;
-                    int new_ml = (lcl + 1) * 2;
-                    idx->length_bitmaps_lower    = (RoaringBitmap **) repalloc(idx->length_bitmaps_lower,    new_ml * sizeof(RoaringBitmap *));
-                    idx->length_ge_bitmaps_lower = (RoaringBitmap **) repalloc(idx->length_ge_bitmaps_lower, new_ml * sizeof(RoaringBitmap *));
-                    for (int i = old_ml; i < new_ml; i++) { idx->length_bitmaps_lower[i] = NULL; idx->length_ge_bitmaps_lower[i] = biscuit_roaring_create(); }
-                    idx->max_length_lower = new_ml;
+                    int old_ml = idx->max_length_legacy;
+                    int new_ml = (cl + 1) * 2;
+
+                    /*
+                     * FIX 1 (belt-and-suspenders): after biscuit_complete_preload_local
+                     * above these are guaranteed non-NULL, but guard anyway so that
+                     * any future caller path that skips the preload check cannot crash.
+                     */
+                    if (idx->length_bitmaps_legacy)
+                        idx->length_bitmaps_legacy    = (RoaringBitmap **) repalloc(idx->length_bitmaps_legacy,    new_ml * sizeof(RoaringBitmap *));
+                    else
+                        idx->length_bitmaps_legacy    = (RoaringBitmap **) palloc0(new_ml * sizeof(RoaringBitmap *));
+
+                    if (idx->length_ge_bitmaps_legacy)
+                        idx->length_ge_bitmaps_legacy = (RoaringBitmap **) repalloc(idx->length_ge_bitmaps_legacy, new_ml * sizeof(RoaringBitmap *));
+                    else
+                        idx->length_ge_bitmaps_legacy = (RoaringBitmap **) palloc0(new_ml * sizeof(RoaringBitmap *));
+
+                    for (int i = old_ml; i < new_ml; i++)
+                    {
+                        idx->length_bitmaps_legacy[i]    = NULL;
+                        idx->length_ge_bitmaps_legacy[i] = biscuit_roaring_create();
+                    }
+                    idx->max_length_legacy = new_ml;
                 }
-                if (!idx->length_bitmaps_lower[lcl]) idx->length_bitmaps_lower[lcl] = biscuit_roaring_create();
-                biscuit_roaring_add(idx->length_bitmaps_lower[lcl], slot);
-                for (int i = 0; i <= lcl && i < idx->max_length_lower; i++)
-                    biscuit_roaring_add(idx->length_ge_bitmaps_lower[i], slot);
-            }
+                if (!idx->length_bitmaps_legacy[cl])
+                    idx->length_bitmaps_legacy[cl] = biscuit_roaring_create();
+                biscuit_roaring_add(idx->length_bitmaps_legacy[cl], slot);
+                for (int i = 0; i <= cl && i < idx->max_length_legacy; i++)
+                    biscuit_roaring_add(idx->length_ge_bitmaps_legacy[i], slot);
+
+                /*
+                 * Lowercase length bitmaps.
+                 * data_cache_lower[slot] was populated by biscuit_index_single_record
+                 * above; for a NULL-valued column this slot was zeroed by FIX A so
+                 * the guard below is always reliable.
+                 */
+                if (idx->data_cache_lower[slot])
+                {
+                    int lbl = strlen(idx->data_cache_lower[slot]);
+                    int lcl = biscuit_utf8_char_count(idx->data_cache_lower[slot], lbl);
+                    if (lcl >= idx->max_length_lower)
+                    {
+                        int old_ml = idx->max_length_lower;
+                        int new_ml = (lcl + 1) * 2;
+
+                        if (idx->length_bitmaps_lower)
+                            idx->length_bitmaps_lower    = (RoaringBitmap **) repalloc(idx->length_bitmaps_lower,    new_ml * sizeof(RoaringBitmap *));
+                        else
+                            idx->length_bitmaps_lower    = (RoaringBitmap **) palloc0(new_ml * sizeof(RoaringBitmap *));
+
+                        if (idx->length_ge_bitmaps_lower)
+                            idx->length_ge_bitmaps_lower = (RoaringBitmap **) repalloc(idx->length_ge_bitmaps_lower, new_ml * sizeof(RoaringBitmap *));
+                        else
+                            idx->length_ge_bitmaps_lower = (RoaringBitmap **) palloc0(new_ml * sizeof(RoaringBitmap *));
+
+                        for (int i = old_ml; i < new_ml; i++)
+                        {
+                            idx->length_bitmaps_lower[i]    = NULL;
+                            idx->length_ge_bitmaps_lower[i] = biscuit_roaring_create();
+                        }
+                        idx->max_length_lower = new_ml;
+                    }
+                    if (!idx->length_bitmaps_lower[lcl])
+                        idx->length_bitmaps_lower[lcl] = biscuit_roaring_create();
+                    biscuit_roaring_add(idx->length_bitmaps_lower[lcl], slot);
+                    for (int i = 0; i <= lcl && i < idx->max_length_lower; i++)
+                        biscuit_roaring_add(idx->length_ge_bitmaps_lower[i], slot);
+                }
             } /* end cl block */
         }
         else
@@ -1127,13 +1200,9 @@ biscuit_insert(Relation index,
             if (!isnull[col])
             {
                 int   out_len;
-                char *str = biscuit_datum_to_text(values[col], idx->column_types[col], &idx->output_funcs[col], &out_len);
+                char *str = biscuit_datum_to_text(values[col], idx->column_types[col],
+                                                  &idx->output_funcs[col], &out_len);
                 idx->column_data_cache[col][slot] = str;
-
-                /*
-                 * FIX 3 (pre-existing): call was previously missing, causing
-                 * every post-build insert to be absent from all bitmaps.
-                 */
                 biscuit_index_column_record(idx, col, str, out_len, slot);
             }
             else
@@ -1143,6 +1212,21 @@ biscuit_insert(Relation index,
 
     if (!found_existing && !is_reusing_slot)
         idx->insert_count++;
+
+    /*
+     * FIX 2 — INSERT → SELECT returns 0.
+     *
+     * After modifying idx the preload_state is guaranteed DONE (we called
+     * biscuit_complete_preload_local at the top if it wasn't already).
+     * Write the warm index back into the global cache so the next beginscan
+     * — whether in this session or after an rd_amcache eviction — picks up
+     * the newly inserted record via the bitmap path instead of loading a
+     * stale skeleton that predates the insert.
+     *
+     * Without this, a SELECT immediately after a committed INSERT finds the
+     * pre-insert cache entry and returns 0 rows.
+     */
+    biscuit_cache_insert(RelationGetRelid(index), idx);
 
     MemoryContextSwitchTo(oldcontext);
 

--- a/src/biscuit_index.c
+++ b/src/biscuit_index.c
@@ -697,10 +697,11 @@ biscuit_build(Relation heap, Relation index, IndexInfo *indexInfo)
              * each with the same character-level logic.
              * (Abbreviated here — mirrors single-column per column.)
              */
-            idx->column_types      = (Oid *)        palloc(natts * sizeof(Oid));
-            idx->output_funcs      = (FmgrInfo *)   palloc(natts * sizeof(FmgrInfo));
-            idx->column_data_cache = (char ***)     palloc(natts * sizeof(char **));
-            idx->column_indices    = (ColumnIndex *) palloc0(natts * sizeof(ColumnIndex));
+            idx->column_types            = (Oid *)        palloc(natts * sizeof(Oid));
+            idx->output_funcs            = (FmgrInfo *)   palloc(natts * sizeof(FmgrInfo));
+            idx->column_data_cache       = (char ***)     palloc(natts * sizeof(char **));
+            idx->column_data_cache_lower = (char ***)     palloc(natts * sizeof(char **));
+            idx->column_indices          = (ColumnIndex *) palloc0(natts * sizeof(ColumnIndex));
 
             for (col = 0; col < natts; col++)
             {
@@ -713,7 +714,8 @@ biscuit_build(Relation heap, Relation index, IndexInfo *indexInfo)
                 idx->column_types[col] = col_attr->atttypid;
                 getTypeOutputInfo(col_attr->atttypid, &typoutput, &typIsVarlena);
                 fmgr_info(typoutput, &idx->output_funcs[col]);
-                idx->column_data_cache[col] = (char **) palloc0(idx->capacity * sizeof(char *));
+                idx->column_data_cache[col]       = (char **) palloc0(idx->capacity * sizeof(char *));
+                idx->column_data_cache_lower[col] = (char **) palloc0(idx->capacity * sizeof(char *));
 
                 for (ch = 0; ch < CHAR_RANGE; ch++)
                 {
@@ -756,7 +758,12 @@ biscuit_build(Relation heap, Relation index, IndexInfo *indexInfo)
                     idx->capacity *= 2;
                     idx->tids = (ItemPointerData *) repalloc(idx->tids, idx->capacity * sizeof(ItemPointerData));
                     for (col = 0; col < natts; col++)
-                        idx->column_data_cache[col] = (char **) repalloc(idx->column_data_cache[col], idx->capacity * sizeof(char *));
+                    {
+                        idx->column_data_cache[col] = (char **) repalloc(
+                            idx->column_data_cache[col], idx->capacity * sizeof(char *));
+                        idx->column_data_cache_lower[col] = (char **) repalloc(
+                            idx->column_data_cache_lower[col], idx->capacity * sizeof(char *));
+                    }
                 }
 
                 ItemPointerCopy(&slot->tts_tid, &idx->tids[idx->num_records]);
@@ -769,10 +776,16 @@ biscuit_build(Relation heap, Relation index, IndexInfo *indexInfo)
                     char      *str;
 
                     val = slot_getattr(slot, index->rd_index->indkey.values[col], &isnull);
-                    if (isnull) { idx->column_data_cache[col][idx->num_records] = NULL; continue; }
+                    if (isnull)
+                    {
+                        idx->column_data_cache[col][idx->num_records]       = NULL;
+                        idx->column_data_cache_lower[col][idx->num_records] = NULL;
+                        continue;
+                    }
 
                     str = biscuit_datum_to_text(val, idx->column_types[col], &idx->output_funcs[col], &out_len);
-                    idx->column_data_cache[col][idx->num_records] = str;
+                    idx->column_data_cache[col][idx->num_records]       = str;
+                    idx->column_data_cache_lower[col][idx->num_records] = biscuit_str_tolower(str, out_len);
 
                     /*
                      * Populate all character-level and case-insensitive bitmaps
@@ -1023,8 +1036,19 @@ biscuit_insert(Relation index,
             else
             {
                 for (col = 0; col < idx->num_columns; col++)
+                {
                     if (idx->column_data_cache[col][slot])
-                        { pfree(idx->column_data_cache[col][slot]); idx->column_data_cache[col][slot] = NULL; }
+                    {
+                        pfree(idx->column_data_cache[col][slot]);
+                        idx->column_data_cache[col][slot] = NULL;
+                    }
+                    if (idx->column_data_cache_lower &&
+                        idx->column_data_cache_lower[col][slot])
+                    {
+                        pfree(idx->column_data_cache_lower[col][slot]);
+                        idx->column_data_cache_lower[col][slot] = NULL;
+                    }
+                }
             }
 
             /* Un-tombstone if needed */
@@ -1085,6 +1109,20 @@ biscuit_insert(Relation index,
                      */
                     memset(idx->column_data_cache[col] + old_cap, 0,
                            (idx->capacity - old_cap) * sizeof(char *));
+
+                    /*
+                     * FIX C: Grow and zero-init column_data_cache_lower in
+                     * lockstep.  Without this the array is shorter than
+                     * column_data_cache; fallback scans on newly-appended
+                     * slots read off the end of the allocation.
+                     */
+                    if (idx->column_data_cache_lower)
+                    {
+                        idx->column_data_cache_lower[col] = (char **) repalloc(
+                            idx->column_data_cache_lower[col], idx->capacity * sizeof(char *));
+                        memset(idx->column_data_cache_lower[col] + old_cap, 0,
+                               (idx->capacity - old_cap) * sizeof(char *));
+                    }
                 }
             }
         }
@@ -1203,10 +1241,24 @@ biscuit_insert(Relation index,
                 char *str = biscuit_datum_to_text(values[col], idx->column_types[col],
                                                   &idx->output_funcs[col], &out_len);
                 idx->column_data_cache[col][slot] = str;
+
+                /*
+                 * Pre-compute the lowercased copy so that biscuit_fallback_scan
+                 * can use column_data_cache_lower directly for ILIKE queries,
+                 * matching the invariant established at build / skeleton load time.
+                 * Mirror NULL to NULL for the null-column case handled below.
+                 */
+                if (idx->column_data_cache_lower)
+                    idx->column_data_cache_lower[col][slot] = biscuit_str_tolower(str, out_len);
+
                 biscuit_index_column_record(idx, col, str, out_len, slot);
             }
             else
+            {
                 idx->column_data_cache[col][slot] = NULL;
+                if (idx->column_data_cache_lower)
+                    idx->column_data_cache_lower[col][slot] = NULL;
+            }
         }
     }
 
@@ -1389,8 +1441,19 @@ biscuit_bulkdelete(IndexVacuumInfo *info,
 
                 for (j = 0; j < (int) delete_count; j++)
                     for (col = 0; col < idx->num_columns; col++)
+                    {
                         if (idx->column_data_cache[col][delete_indices[j]])
-                            { pfree(idx->column_data_cache[col][delete_indices[j]]); idx->column_data_cache[col][delete_indices[j]] = NULL; }
+                        {
+                            pfree(idx->column_data_cache[col][delete_indices[j]]);
+                            idx->column_data_cache[col][delete_indices[j]] = NULL;
+                        }
+                        if (idx->column_data_cache_lower &&
+                            idx->column_data_cache_lower[col][delete_indices[j]])
+                        {
+                            pfree(idx->column_data_cache_lower[col][delete_indices[j]]);
+                            idx->column_data_cache_lower[col][delete_indices[j]] = NULL;
+                        }
+                    }
             }
 
             pfree(delete_indices);

--- a/src/biscuit_index.c
+++ b/src/biscuit_index.c
@@ -1012,10 +1012,11 @@ biscuit_insert(Relation index,
      * This also fixes the mirrored hazard in the multi-column path where
      * cidx->length_bitmaps / length_ge_bitmaps are NULL in a skeleton.
      */
+     
+    oldcontext = MemoryContextSwitchTo(CacheMemoryContext);
     if (idx->preload_state < BISCUIT_PRELOAD_DONE)
         biscuit_complete_preload_local(idx, RelationGetRelid(index));
 
-    oldcontext = MemoryContextSwitchTo(CacheMemoryContext);
 
     /* Check for duplicate TID (UPDATE path) */
     for (int i = 0; i < idx->num_records; i++)

--- a/src/biscuit_pattern.c
+++ b/src/biscuit_pattern.c
@@ -2327,16 +2327,23 @@ biscuit_query_column_pattern_ilike(BiscuitIndex *idx, int col_idx, const char *p
                         while (iter->has_value)
                         {
                             uint32_t    rec = iter->current_value;
-                            const char *hay_orig;
+                            const char *hay;
+                            /*
+                             * Use the pre-lowercased cache populated at build /
+                             * skeleton-load / insert time.  This avoids a
+                             * palloc + tolower + pfree per candidate — the hot
+                             * path inside an already bitmap-pruned set.
+                             * column_data_cache_lower mirrors column_data_cache
+                             * slot-for-slot; a NULL entry means the source value
+                             * was NULL, so the same guard applies.
+                             */
                             if (rec < (uint32_t) idx->num_records &&
-                                idx->column_data_cache &&
-                                idx->column_data_cache[col_idx] &&
-                                (hay_orig = idx->column_data_cache[col_idx][rec]) != NULL)
+                                idx->column_data_cache_lower &&
+                                idx->column_data_cache_lower[col_idx] &&
+                                (hay = idx->column_data_cache_lower[col_idx][rec]) != NULL)
                             {
-                                char *hay_lower = biscuit_str_tolower(hay_orig, strlen(hay_orig));
-                                if (strstr(hay_lower, parsed->parts[0]) != NULL)
+                                if (strstr(hay, parsed->parts[0]) != NULL)
                                     biscuit_roaring_add(result, rec);
-                                pfree(hay_lower);
                             }
                             roaring_uint32_iterator_advance(iter);
                         }
@@ -2352,16 +2359,14 @@ biscuit_query_column_pattern_ilike(BiscuitIndex *idx, int col_idx, const char *p
                             for (j = 0; j < (int) cnt; j++)
                             {
                                 uint32_t    rec = indices[j];
-                                const char *hay_orig;
+                                const char *hay;
                                 if (rec < (uint32_t) idx->num_records &&
-                                    idx->column_data_cache &&
-                                    idx->column_data_cache[col_idx] &&
-                                    (hay_orig = idx->column_data_cache[col_idx][rec]) != NULL)
+                                    idx->column_data_cache_lower &&
+                                    idx->column_data_cache_lower[col_idx] &&
+                                    (hay = idx->column_data_cache_lower[col_idx][rec]) != NULL)
                                 {
-                                    char *hay_lower = biscuit_str_tolower(hay_orig, strlen(hay_orig));
-                                    if (strstr(hay_lower, parsed->parts[0]) != NULL)
+                                    if (strstr(hay, parsed->parts[0]) != NULL)
                                         biscuit_roaring_add(result, rec);
-                                    pfree(hay_lower);
                                 }
                             }
                             pfree(indices);

--- a/src/biscuit_preload.c
+++ b/src/biscuit_preload.c
@@ -469,6 +469,11 @@ biscuit_load_skeleton(Relation index)
 
     /* Mark as skeleton only — bitmaps not yet built */
     idx->preload_state = BISCUIT_PRELOAD_SKELETON;
+    
+    /* If the worker already signalled DONE, build bitmaps now
+     * so the returned index is immediately warm and consistent with shmem. */
+    if (biscuit_preload_state(RelationGetRelid(index)) >= BISCUIT_PRELOAD_DONE)
+        biscuit_complete_preload_local(idx, RelationGetRelid(index));
 
     MemoryContextSwitchTo(oldcontext);
 

--- a/src/biscuit_preload.c
+++ b/src/biscuit_preload.c
@@ -331,10 +331,11 @@ biscuit_load_skeleton(Relation index)
     }
     else
     {
-        idx->column_types      = (Oid *)        palloc(natts * sizeof(Oid));
-        idx->output_funcs      = (FmgrInfo *)   palloc(natts * sizeof(FmgrInfo));
-        idx->column_data_cache = (char ***)     palloc(natts * sizeof(char **));
-        idx->column_indices    = (ColumnIndex *) palloc0(natts * sizeof(ColumnIndex));
+        idx->column_types            = (Oid *)        palloc(natts * sizeof(Oid));
+        idx->output_funcs            = (FmgrInfo *)   palloc(natts * sizeof(FmgrInfo));
+        idx->column_data_cache       = (char ***)     palloc(natts * sizeof(char **));
+        idx->column_data_cache_lower = (char ***)     palloc(natts * sizeof(char **));
+        idx->column_indices          = (ColumnIndex *) palloc0(natts * sizeof(ColumnIndex));
 
         for (col = 0; col < natts; col++)
         {
@@ -347,7 +348,8 @@ biscuit_load_skeleton(Relation index)
             idx->column_types[col] = col_attr->atttypid;
             getTypeOutputInfo(col_attr->atttypid, &typoutput, &typIsVarlena);
             fmgr_info(typoutput, &idx->output_funcs[col]);
-            idx->column_data_cache[col] = (char **) palloc0(idx->capacity * sizeof(char *));
+            idx->column_data_cache[col]       = (char **) palloc0(idx->capacity * sizeof(char *));
+            idx->column_data_cache_lower[col] = (char **) palloc0(idx->capacity * sizeof(char *));
 
             for (ch = 0; ch < CHAR_RANGE; ch++)
             {
@@ -402,9 +404,14 @@ biscuit_load_skeleton(Relation index)
             else
             {
                 for (col = 0; col < natts; col++)
+                {
                     idx->column_data_cache[col] = (char **) repalloc(
                         idx->column_data_cache[col],
                         idx->capacity * sizeof(char *));
+                    idx->column_data_cache_lower[col] = (char **) repalloc(
+                        idx->column_data_cache_lower[col],
+                        idx->capacity * sizeof(char *));
+                }
             }
         }
 
@@ -457,6 +464,20 @@ biscuit_load_skeleton(Relation index)
                                               &out_len);
                 else
                     idx->column_data_cache[col][idx->num_records] = NULL;
+
+                /*
+                 * Pre-compute the lowercased copy for ILIKE fallback scans.
+                 * biscuit_fallback_scan() reads column_data_cache_lower
+                 * directly, avoiding a per-record palloc during query
+                 * execution.  Mirror NULL entries exactly.
+                 */
+                if (idx->column_data_cache[col][idx->num_records])
+                    idx->column_data_cache_lower[col][idx->num_records] =
+                        biscuit_str_tolower(
+                            idx->column_data_cache[col][idx->num_records],
+                            strlen(idx->column_data_cache[col][idx->num_records]));
+                else
+                    idx->column_data_cache_lower[col][idx->num_records] = NULL;
             }
         }
 
@@ -1063,7 +1084,25 @@ biscuit_fallback_scan(BiscuitIndex *idx,
         else
         {
             if (col_idx < 0 || col_idx >= idx->num_columns) continue;
-            str = idx->column_data_cache[col_idx][i];
+            if (ilike)
+            {
+                /*
+                 * Use the pre-lowercased cache populated at build / skeleton
+                 * load time.  This avoids a palloc + memcpy + pfree on every
+                 * record for every ILIKE fallback scan.
+                 *
+                 * column_data_cache_lower is guaranteed non-NULL here: it is
+                 * allocated alongside column_data_cache in both biscuit_build
+                 * (biscuit_index.c) and biscuit_load_skeleton (this file).
+                 * Per-slot entries are NULL iff the source value was NULL,
+                 * which is caught by the "if (!str) continue" below.
+                 */
+                str = idx->column_data_cache_lower[col_idx][i];
+            }
+            else
+            {
+                str = idx->column_data_cache[col_idx][i];
+            }
         }
 
         if (!str) continue;

--- a/src/biscuit_preload.c
+++ b/src/biscuit_preload.c
@@ -942,6 +942,82 @@ biscuit_complete_preload_local(BiscuitIndex *idx, Oid indexoid)
  * Sequential string scan used while bitmaps are not yet ready.
  * ================================================================ */
 
+/*
+ * biscuit_like_match
+ * -------------------
+ * Correct, UTF-8-aware backtracking LIKE/ILIKE matcher.  Honors the same
+ * escape convention as the rest of this extension (backslash escapes the
+ * following character, so '\%' / '\_' / '\\' are literals, not wildcards).
+ *
+ * '%' matches zero or more characters; '_' matches exactly one UTF-8
+ * character.  Backtracks on '%' the standard way: remember the last '%'
+ * position and the haystack position right after it, and on a mismatch
+ * retry by having that '%' consume one more character.
+ *
+ * hay/hay_len and pat/pat_len are byte buffers; ilike compares using
+ * lower-cased single bytes (callers pass already-lower-cased hay+pattern
+ * for ILIKE, matching the convention used elsewhere in this file).
+ */
+static bool
+biscuit_like_match(const char *hay, int hay_len, const char *pat, int pat_len)
+{
+    int hi = 0, pi = 0;
+    int star_pi = -1, star_hi = -1;
+
+    while (hi < hay_len)
+    {
+        if (pi < pat_len && pat[pi] == '\\' && pi + 1 < pat_len)
+        {
+            /* literal escaped char must match exactly (1 byte) */
+            if (hay[hi] == pat[pi + 1])
+            {
+                hi++;
+                pi += 2;
+                continue;
+            }
+        }
+        else if (pi < pat_len && pat[pi] == '_')
+        {
+            int cl = biscuit_utf8_char_length((unsigned char) hay[hi]);
+            if (hi + cl > hay_len)
+                cl = hay_len - hi;
+            hi += cl;
+            pi += 1;
+            continue;
+        }
+        else if (pi < pat_len && pat[pi] == '%')
+        {
+            star_pi = pi++;
+            star_hi = hi;
+            continue;
+        }
+        else if (pi < pat_len && hay[hi] == pat[pi])
+        {
+            hi++;
+            pi++;
+            continue;
+        }
+
+        /* mismatch: backtrack to the most recent '%' if any */
+        if (star_pi >= 0)
+        {
+            pi = star_pi + 1;
+            star_hi += biscuit_utf8_char_length((unsigned char) hay[star_hi]);
+            if (star_hi > hay_len)
+                return false;
+            hi = star_hi;
+            continue;
+        }
+        return false;
+    }
+
+    /* consume any trailing '%' (and reject any other trailing pattern) */
+    while (pi < pat_len && pat[pi] == '%')
+        pi++;
+
+    return pi == pat_len;
+}
+
 void
 biscuit_fallback_scan(BiscuitIndex *idx,
                       const char   *pattern,
@@ -954,181 +1030,16 @@ biscuit_fallback_scan(BiscuitIndex *idx,
     int              capacity = 256;
     int              count    = 0;
     ItemPointerData *tids     = (ItemPointerData *) palloc(capacity * sizeof(ItemPointerData));
+    const char      *match_pattern = pattern;
+    char            *pattern_lower = NULL;
+    int              pat_len;
 
-    /*
-     * Translate LIKE wildcards to a simple prefix+suffix+substring check.
-     * For the warm-up window this does not need to be perfectly optimal —
-     * just correct.  We use pg_strcasecmp for ILIKE.
-     */
-    bool   has_prefix  = false;
-    bool   has_suffix  = false;
-    bool   is_exact    = false;
-    char  *prefix      = NULL;
-    char  *suffix      = NULL;
-    char  *substring   = NULL;
-    int    prefix_len  = 0;
-    int    suffix_len  = 0;
-    int    sub_len     = 0;
-
-    /* Simple pattern decomposition: find leading/trailing literal parts.
-     * Backslash-escape sequences are unescaped:
-     *   \% -> literal %   \_ -> literal _   \\ -> literal \
-     * Unescaped '_' is a single-char wildcard: we represent it as a
-     * single NUL placeholder so prefix/suffix length accounting is correct,
-     * but we cannot do a simple strncmp with wildcards present — we fall
-     * back to a full character-by-character match in that case.
-     */
+    if (ilike)
     {
-        const char *p   = pattern;
-        int         plen_raw = strlen(pattern);
-        const char *end = pattern + plen_raw;
-        const char *q;
-        int         pct_count = 0;
-        bool        has_underscore_wildcard = false;
-
-        for (q = p; q < end; q++)
-        {
-            if (*q == '\\' && q + 1 < end)
-            {
-                q++; /* skip escaped char, not a wildcard */
-            }
-            else if (*q == '%')
-                pct_count++;
-            else if (*q == '_')
-                has_underscore_wildcard = true;
-        }
-
-        if (pct_count == 0 && !has_underscore_wildcard)
-        {
-            /* exact match — unescape the pattern */
-            char *unesc = (char *) palloc(plen_raw + 1);
-            int   ui    = 0;
-            for (q = p; q < end; q++)
-            {
-                if (*q == '\\' && q + 1 < end)
-                    unesc[ui++] = *++q;
-                else
-                    unesc[ui++] = *q;
-            }
-            unesc[ui] = '\0';
-            is_exact   = true;
-            prefix     = unesc;
-            prefix_len = ui;
-        }
-        else if (has_underscore_wildcard || pct_count > 0)
-        {
-            /*
-             * General pattern: extract unescaped prefix (before the first
-             * unescaped '%' or '_'), suffix (after the last unescaped '%'),
-             * and a middle substring for quick pre-filtering.
-             *
-             * When '_' wildcards appear, prefix matching is done
-             * character-by-character further down; we still extract the
-             * concrete prefix bytes up to (but not including) the first
-             * wildcard for a quick rejection test.
-             */
-            const char *first_wild = NULL;
-            const char *last_pct   = NULL;
-
-            /* Find positions of first wildcard and last unescaped % */
-            for (q = p; q < end; q++)
-            {
-                if (*q == '\\' && q + 1 < end)
-                {
-                    q++;
-                    continue;
-                }
-                if (*q == '%' || *q == '_')
-                {
-                    if (!first_wild)
-                        first_wild = q;
-                    if (*q == '%')
-                        last_pct = q;
-                }
-            }
-
-            /* Unescaped prefix before first wildcard */
-            if (first_wild && first_wild > p)
-            {
-                char *unesc = (char *) palloc((first_wild - p) + 1);
-                int   ui    = 0;
-                for (q = p; q < first_wild; q++)
-                {
-                    if (*q == '\\' && q + 1 < first_wild)
-                        unesc[ui++] = *++q;
-                    else
-                        unesc[ui++] = *q;
-                }
-                unesc[ui]  = '\0';
-                prefix      = unesc;
-                prefix_len  = ui;
-                has_prefix  = (ui > 0);
-            }
-
-            /* Unescaped suffix after last unescaped % */
-            if (last_pct && last_pct < end - 1)
-            {
-                const char *sf = last_pct + 1;
-                char *unesc    = (char *) palloc((end - sf) + 1);
-                int   ui       = 0;
-                for (q = sf; q < end; q++)
-                {
-                    if (*q == '\\' && q + 1 < end)
-                        unesc[ui++] = *++q;
-                    else if (*q == '_')
-                    {
-                        /* suffix with wildcard: can't use simple strcmp */
-                        ui = 0;
-                        has_suffix = false;
-                        break;
-                    }
-                    else
-                        unesc[ui++] = *q;
-                }
-                if (ui > 0)
-                {
-                    unesc[ui]  = '\0';
-                    suffix      = unesc;
-                    suffix_len  = ui;
-                    has_suffix  = true;
-                }
-                else
-                    pfree(unesc);
-            }
-
-            /* Middle literal run for substring pre-filtering */
-            if (last_pct && first_wild && last_pct > first_wild)
-            {
-                const char *s = first_wild + 1;
-                const char *e_scan;
-                /* skip any leading %/_  */
-                while (s < last_pct && (*s == '%' || *s == '_')) s++;
-                e_scan = s;
-                while (e_scan < last_pct && *e_scan != '%' && *e_scan != '_')
-                {
-                    if (*e_scan == '\\' && e_scan + 1 < last_pct)
-                        e_scan++;
-                    e_scan++;
-                }
-                if (e_scan > s)
-                {
-                    /* Unescape the middle run */
-                    char *unesc = (char *) palloc((e_scan - s) + 1);
-                    int   ui    = 0;
-                    for (q = s; q < e_scan; q++)
-                    {
-                        if (*q == '\\' && q + 1 < e_scan)
-                            unesc[ui++] = *++q;
-                        else
-                            unesc[ui++] = *q;
-                    }
-                    unesc[ui]  = '\0';
-                    substring   = unesc;
-                    sub_len     = ui;
-                }
-            }
-        }
+        pattern_lower = biscuit_str_tolower(pattern, strlen(pattern));
+        match_pattern = pattern_lower;
     }
+    pat_len = strlen(match_pattern);
 
     for (i = 0; i < idx->num_records; i++)
     {
@@ -1157,79 +1068,19 @@ biscuit_fallback_scan(BiscuitIndex *idx,
 
         if (!str) continue;
 
-        /* Match */
+        if (biscuit_like_match(str, strlen(str), match_pattern, pat_len))
         {
-            bool match = false;
-            int  slen  = strlen(str);
-
-            if (is_exact)
+            if (count >= capacity)
             {
-                match = (ilike ? pg_strcasecmp(str, prefix) == 0
-                               : strcmp(str, prefix) == 0);
+                capacity *= 2;
+                tids = (ItemPointerData *) repalloc(
+                    tids, capacity * sizeof(ItemPointerData));
             }
-            else
-            {
-                bool ok = true;
-
-                /* prefix check */
-                if (has_prefix && prefix_len > 0)
-                {
-                    if (ilike)
-                        ok = (pg_strncasecmp(str, prefix, prefix_len) == 0);
-                    else
-                        ok = (strncmp(str, prefix, prefix_len) == 0);
-                }
-
-                /* suffix check */
-                if (ok && has_suffix && suffix_len > 0 && slen >= suffix_len)
-                {
-                    const char *str_end = str + slen - suffix_len;
-                    if (ilike)
-                        ok = (pg_strcasecmp(str_end, suffix) == 0);
-                    else
-                        ok = (strcmp(str_end, suffix) == 0);
-                }
-                else if (ok && has_suffix && slen < suffix_len)
-                    ok = false;
-
-                /* substring check */
-                if (ok && substring && sub_len > 0)
-                {
-                    if (ilike)
-                    {
-                        /* case-insensitive substring: scan manually */
-                        bool found = false;
-                        int  j;
-                        for (j = 0; j <= slen - sub_len; j++)
-                        {
-                            if (pg_strncasecmp(str + j, substring, sub_len) == 0)
-                            { found = true; break; }
-                        }
-                        ok = found;
-                    }
-                    else
-                        ok = (strstr(str, substring) != NULL);
-                }
-
-                match = ok;
-            }
-
-            if (match)
-            {
-                if (count >= capacity)
-                {
-                    capacity *= 2;
-                    tids = (ItemPointerData *) repalloc(
-                        tids, capacity * sizeof(ItemPointerData));
-                }
-                ItemPointerCopy(&idx->tids[i], &tids[count++]);
-            }
+            ItemPointerCopy(&idx->tids[i], &tids[count++]);
         }
     }
 
-    if (prefix)    pfree(prefix);
-    if (suffix)    pfree(suffix);
-    if (substring) pfree(substring);
+    if (pattern_lower) pfree(pattern_lower);
 
     *out_tids  = tids;
     *out_count = count;

--- a/src/biscuit_scan.c
+++ b/src/biscuit_scan.c
@@ -357,10 +357,7 @@ biscuit_rescan_multicolumn_fallback(IndexScanDesc scan,
             if (col_idx < 0 || col_idx >= so->index->num_columns)
                 continue;
 
-            is_ilike = (key->sk_strategy == BISCUIT_ILIKE_STRATEGY ||
-                        key->sk_strategy == BISCUIT_NOT_ILIKE_STRATEGY);
-            is_not   = (key->sk_strategy == BISCUIT_NOT_LIKE_STRATEGY ||
-                        key->sk_strategy == BISCUIT_NOT_ILIKE_STRATEGY);
+            
 
             pattern_text = DatumGetTextPP(key->sk_argument);
             pattern      = text_to_cstring(pattern_text);
@@ -397,6 +394,11 @@ biscuit_rescan_multicolumn_fallback(IndexScanDesc scan,
             }
             if (key_tids)
                 pfree(key_tids);
+
+            is_ilike = (key->sk_strategy == BISCUIT_ILIKE_STRATEGY ||
+                        key->sk_strategy == BISCUIT_NOT_ILIKE_STRATEGY);
+            is_not   = (key->sk_strategy == BISCUIT_NOT_LIKE_STRATEGY ||
+                        key->sk_strategy == BISCUIT_NOT_ILIKE_STRATEGY);
 
             if (is_not)
             {
@@ -580,8 +582,7 @@ biscuit_rescan(IndexScanDesc scan,
                 if (key->sk_flags & SK_ISNULL)
                     continue;
 
-                is_not = (key->sk_strategy == BISCUIT_NOT_LIKE_STRATEGY ||
-                          key->sk_strategy == BISCUIT_NOT_ILIKE_STRATEGY);
+                
 
                 pattern_text = DatumGetTextPP(key->sk_argument);
                 pattern      = text_to_cstring(pattern_text);
@@ -616,6 +617,9 @@ biscuit_rescan(IndexScanDesc scan,
                     return;
                 }
                 
+                is_not = (key->sk_strategy == BISCUIT_NOT_LIKE_STRATEGY ||
+                          key->sk_strategy == BISCUIT_NOT_ILIKE_STRATEGY);
+                          
                 if (is_not)
                 {
                     /*

--- a/src/biscuit_scan.c
+++ b/src/biscuit_scan.c
@@ -133,11 +133,9 @@ biscuit_rescan_multicolumn(IndexScanDesc scan,
     RoaringBitmap     *candidates;
     QueryPlan         *plan;
     bool               needs_sorting;
-    int                limit_hint;
     int                i;
 
     needs_sorting = so->needs_sorted_access;
-    limit_hint    = so->limit_remaining;
 
     /* Start with all records as candidates */
     candidates = biscuit_roaring_create();
@@ -217,9 +215,9 @@ biscuit_rescan_multicolumn(IndexScanDesc scan,
             break;
     }
 
-    biscuit_collect_tids_optimized(so->index, candidates,
-                                   &so->results, &so->num_results,
-                                   needs_sorting, limit_hint);
+    biscuit_collect_sorted_tids_parallel(so->index, candidates,
+                                         &so->results, &so->num_results,
+                                         needs_sorting);
 
     biscuit_roaring_free(candidates);
 
@@ -386,9 +384,9 @@ biscuit_rescan_multicolumn_fallback(IndexScanDesc scan,
         if (so->index->tombstone_count > 0 && so->index->tombstones)
             biscuit_roaring_andnot_inplace(candidates, so->index->tombstones);
 
-        biscuit_collect_tids_optimized(so->index, candidates,
-                                       &so->results, &so->num_results,
-                                       needs_sorting, so->limit_remaining);
+        biscuit_collect_sorted_tids_parallel(so->index, candidates,
+                                             &so->results, &so->num_results,
+                                             needs_sorting);
 
         biscuit_roaring_free(candidates);
     }
@@ -414,7 +412,6 @@ biscuit_rescan(IndexScanDesc scan,
     BiscuitScanOpaque *so = (BiscuitScanOpaque *) scan->opaque;
     bool               is_aggregate;
     bool               needs_sorting;
-    int                limit_hint;
     bool               bitmaps_ready;
 
     if (so->results)
@@ -444,11 +441,10 @@ biscuit_rescan(IndexScanDesc scan,
 
     is_aggregate   = biscuit_is_aggregate_query(scan);
     needs_sorting  = !is_aggregate;
-    limit_hint     = biscuit_estimate_limit_hint(scan);
 
     so->is_aggregate_only   = is_aggregate;
     so->needs_sorted_access = needs_sorting;
-    so->limit_remaining     = limit_hint;
+    so->limit_remaining     = -1;
 
     /*
      * Check whether the background worker has finished building the bitmaps.
@@ -530,6 +526,9 @@ biscuit_rescan(IndexScanDesc scan,
 
                 if (key->sk_flags & SK_ISNULL)
                     continue;
+
+                is_not = (key->sk_strategy == BISCUIT_NOT_LIKE_STRATEGY ||
+                          key->sk_strategy == BISCUIT_NOT_ILIKE_STRATEGY);
 
                 pattern_text = DatumGetTextPP(key->sk_argument);
                 pattern      = text_to_cstring(pattern_text);
@@ -622,9 +621,9 @@ biscuit_rescan(IndexScanDesc scan,
             if (so->index->tombstone_count > 0)
                 biscuit_roaring_andnot_inplace(result, so->index->tombstones);
 
-            biscuit_collect_tids_optimized(so->index, result,
-                                           &so->results, &so->num_results,
-                                           needs_sorting, limit_hint);
+            biscuit_collect_sorted_tids_parallel(so->index, result,
+                                                 &so->results, &so->num_results,
+                                                 needs_sorting);
 
             biscuit_roaring_free(result);
         }
@@ -802,9 +801,9 @@ biscuit_rescan(IndexScanDesc scan,
                 if (so->index->tombstone_count > 0 && so->index->tombstones)
                     biscuit_roaring_andnot_inplace(candidates, so->index->tombstones);
 
-                biscuit_collect_tids_optimized(so->index, candidates,
-                                               &so->results, &so->num_results,
-                                               needs_sorting, limit_hint);
+                biscuit_collect_sorted_tids_parallel(so->index, candidates,
+                                                     &so->results, &so->num_results,
+                                                     needs_sorting);
 
                 biscuit_roaring_free(candidates);
             }

--- a/src/biscuit_scan.c
+++ b/src/biscuit_scan.c
@@ -357,7 +357,18 @@ biscuit_rescan_multicolumn_fallback(IndexScanDesc scan,
             if (col_idx < 0 || col_idx >= so->index->num_columns)
                 continue;
 
-            
+            /*
+             * Derive is_ilike and is_not from THIS key's strategy before
+             * passing is_ilike to biscuit_fallback_scan.  Previously these
+             * assignments appeared after the call, leaving is_ilike
+             * uninitialised — an undefined-behaviour read that happened to
+             * produce the first key's value on every iteration, making all
+             * subsequent keys inherit the first key's case-sensitivity.
+             */
+            is_ilike = (key->sk_strategy == BISCUIT_ILIKE_STRATEGY ||
+                        key->sk_strategy == BISCUIT_NOT_ILIKE_STRATEGY);
+            is_not   = (key->sk_strategy == BISCUIT_NOT_LIKE_STRATEGY ||
+                        key->sk_strategy == BISCUIT_NOT_ILIKE_STRATEGY);
 
             pattern_text = DatumGetTextPP(key->sk_argument);
             pattern      = text_to_cstring(pattern_text);
@@ -394,11 +405,6 @@ biscuit_rescan_multicolumn_fallback(IndexScanDesc scan,
             }
             if (key_tids)
                 pfree(key_tids);
-
-            is_ilike = (key->sk_strategy == BISCUIT_ILIKE_STRATEGY ||
-                        key->sk_strategy == BISCUIT_NOT_ILIKE_STRATEGY);
-            is_not   = (key->sk_strategy == BISCUIT_NOT_LIKE_STRATEGY ||
-                        key->sk_strategy == BISCUIT_NOT_ILIKE_STRATEGY);
 
             if (is_not)
             {

--- a/src/biscuit_scan.c
+++ b/src/biscuit_scan.c
@@ -3,6 +3,35 @@
  * Index scan lifecycle: beginscan, rescan (single- and multi-column),
  * gettuple, getbitmap, endscan.
  *
+ * PARALLEL SCAN FIX (see also biscuit_tid.c)
+ * ------------------------------------------
+ * Root cause of the duplicate-row bug
+ * ------------------------------------
+ * biscuit_rescan() always called biscuit_collect_sorted_tids_single(),
+ * which evaluates the full bitmap and returns ALL matching TIDs.  Because
+ * every Gather participant (leader + N workers) executes an independent
+ * amrescan, every participant collected the full result set and Gather
+ * assembled N copies — producing rows=N×expected in EXPLAIN ANALYZE.
+ *
+ * Fix
+ * ---
+ * Both the single-column and multi-column fast paths now call
+ * biscuit_collect_sorted_tids_parallel() when scan->parallel_scan != NULL.
+ * That function handles all coordination internally:
+ *
+ *   • Each participant evaluates the bitmap locally (read-only, deterministic
+ *     → identical result in every process, no DSM pointer sharing needed).
+ *   • An atomic CAS on pdesc->next_chunk (UNINIT→INITING) elects exactly one
+ *     initializer to write total_tids/total_chunks into the shared DSM
+ *     descriptor.  Others spin-wait with CHECK_FOR_INTERRUPTS + 1µs sleep.
+ *   • Every participant then claims a disjoint chunk range atomically and
+ *     returns only those TIDs to Gather — assembling exactly one result copy.
+ *
+ * No changes to BiscuitScanOpaque or biscuit_common.h are required.
+ * No IsParallelWorker() distinction is needed — every participant runs
+ * the same code path.
+ *
+ *
  * Lazy-load strategy
  * ------------------
  * Previously beginscan called biscuit_load_index() synchronously, which
@@ -69,7 +98,9 @@ biscuit_beginscan(Relation index, int nkeys, int norderbys)
 
     if (!so->index)
         so->index = biscuit_cache_lookup(indexoid);
-
+    
+    elog(DEBUG1, "Entered beginscan()");
+    
     if (so->index)
     {
         /*
@@ -124,6 +155,14 @@ biscuit_beginscan(Relation index, int nkeys, int norderbys)
  * Only reached when preload_state == BISCUIT_PRELOAD_DONE.
  * ================================================================ */
 
+/*
+ * biscuit_rescan_multicolumn
+ *
+ * scan is passed through so the function can dispatch to the parallel
+ * or single-threaded TID-collection path exactly as the single-column
+ * fast path in biscuit_rescan() does.  See that path for the full
+ * rationale.
+ */
 static void
 biscuit_rescan_multicolumn(IndexScanDesc scan,
                            ScanKey keys, int nkeys,
@@ -215,9 +254,22 @@ biscuit_rescan_multicolumn(IndexScanDesc scan,
             break;
     }
 
-    biscuit_collect_sorted_tids_parallel(so->index, candidates,
-                                         &so->results, &so->num_results,
-                                         needs_sorting);
+    /* Parallel-aware TID collection — same as single-column fast path. */
+    {
+        BiscuitParallelScanDesc *pdesc = NULL;
+
+        if (scan->parallel_scan != NULL)
+        {
+            pdesc = (BiscuitParallelScanDesc *)
+                        OffsetToPointer(scan->parallel_scan,
+                                        scan->parallel_scan->ps_offset_am);
+        }
+
+        biscuit_collect_sorted_tids_parallel(
+            so->index, candidates, pdesc,
+            &so->results, &so->num_results,
+            needs_sorting);
+    }
 
     biscuit_roaring_free(candidates);
 
@@ -384,7 +436,7 @@ biscuit_rescan_multicolumn_fallback(IndexScanDesc scan,
         if (so->index->tombstone_count > 0 && so->index->tombstones)
             biscuit_roaring_andnot_inplace(candidates, so->index->tombstones);
 
-        biscuit_collect_sorted_tids_parallel(so->index, candidates,
+        biscuit_collect_sorted_tids_single(so->index, candidates,
                                              &so->results, &so->num_results,
                                              needs_sorting);
 
@@ -494,7 +546,7 @@ biscuit_rescan(IndexScanDesc scan,
         }
         else if (shmem_state == BISCUIT_PRELOAD_FAILED)
         {
-            elog(WARNING,
+            elog(DEBUG1,
                  "Biscuit: preload worker failed for index %u; "
                  "using sequential fallback scan (may be slow)",
                  RelationGetRelid(scan->indexRelation));
@@ -504,6 +556,7 @@ biscuit_rescan(IndexScanDesc scan,
     /* ---------------------------------------------------------------
      * FAST PATH – bitmaps are available
      * --------------------------------------------------------------- */
+    elog(DEBUG1, "Entering Checkpoint - 1: 559");
     if (bitmaps_ready)
     {
         if (so->index->num_columns > 1)
@@ -562,7 +615,7 @@ biscuit_rescan(IndexScanDesc scan,
                     if (result) biscuit_roaring_free(result);
                     return;
                 }
-
+                
                 if (is_not)
                 {
                     /*
@@ -598,7 +651,6 @@ biscuit_rescan(IndexScanDesc scan,
                     biscuit_roaring_free(key_result);
                     key_result = all;
                 }
-
                 if (!result)
                     result = key_result;
                 else
@@ -621,9 +673,43 @@ biscuit_rescan(IndexScanDesc scan,
             if (so->index->tombstone_count > 0)
                 biscuit_roaring_andnot_inplace(result, so->index->tombstones);
 
-            biscuit_collect_sorted_tids_parallel(so->index, result,
-                                                 &so->results, &so->num_results,
-                                                 needs_sorting);
+            /*
+             * Parallel-aware TID collection.
+             *
+             * When scan->parallel_scan is set, the Gather node has launched
+             * background workers that will each call biscuit_rescan()
+             * independently on their own private IndexScanDesc.  Without
+             * coordination every participant evaluates the full bitmap and
+             * returns the full TID set, causing N× row duplication.
+             *
+             * Fix: biscuit_collect_sorted_tids_parallel() handles this
+             * transparently.  Every participant (leader and workers alike)
+             * evaluates the bitmap locally — the result is identical for all
+             * because the bitmap and index data are read-only and deterministic.
+             * An atomic CAS on pdesc->next_chunk elects exactly one initializer
+             * which writes total_tids/total_chunks into the shared DSM
+             * descriptor; the others spin-wait.  Then each participant atomically
+             * claims a disjoint chunk range and returns only those TIDs to its
+             * local Gather feeder — so the Gather node assembles exactly one
+             * copy of the full result.
+             *
+             * When scan->parallel_scan is NULL the function is identical to
+             * biscuit_collect_sorted_tids_single().
+             */
+             elog(DEBUG1, "Entering Checkpoint - 3: 700");
+            {
+                BiscuitParallelScanDesc *pdesc = NULL;
+                elog(DEBUG1, "Entering Checkpoint - 2: 702");
+                if (scan->parallel_scan != NULL)
+                    pdesc = (BiscuitParallelScanDesc *)
+                                OffsetToPointer(scan->parallel_scan,
+                                                scan->parallel_scan->ps_offset_am);
+              
+                biscuit_collect_sorted_tids_parallel(
+                    so->index, result, pdesc,
+                    &so->results, &so->num_results,
+                    needs_sorting);
+            }
 
             biscuit_roaring_free(result);
         }
@@ -655,7 +741,7 @@ biscuit_rescan(IndexScanDesc scan,
          * hash map once before the key loop (O(n)) and use it for O(1)
          * lookups per matched TID.
          */
-        elog(DEBUG2,
+        elog(DEBUG1,
              "Biscuit: index %u not yet warm (state=%u); using fallback scan",
              RelationGetRelid(scan->indexRelation),
              so->index->preload_state);
@@ -801,10 +887,23 @@ biscuit_rescan(IndexScanDesc scan,
                 if (so->index->tombstone_count > 0 && so->index->tombstones)
                     biscuit_roaring_andnot_inplace(candidates, so->index->tombstones);
 
-                biscuit_collect_sorted_tids_parallel(so->index, candidates,
+                /*biscuit_collect_sorted_tids_single(so->index, candidates,
                                                      &so->results, &so->num_results,
-                                                     needs_sorting);
-
+                                                     needs_sorting);*/
+               
+                {
+                    BiscuitParallelScanDesc *pdesc = NULL;
+                    elog(DEBUG1, "Entering Checkpoint - 2: 702");
+                    if (scan->parallel_scan != NULL)
+                        pdesc = (BiscuitParallelScanDesc *)
+                                    OffsetToPointer(scan->parallel_scan,
+                                                    scan->parallel_scan->ps_offset_am);
+                  
+                     biscuit_collect_sorted_tids_parallel(
+                        so->index, candidates, pdesc,
+                        &so->results, &so->num_results,
+                        needs_sorting);
+                }
                 biscuit_roaring_free(candidates);
             }
 
@@ -886,4 +985,6 @@ biscuit_endscan(IndexScanDesc scan)
             pfree(so->results);
         pfree(so);
     }
+    
+    elog(DEBUG1, "Exited scan");
 }

--- a/src/biscuit_scan.c
+++ b/src/biscuit_scan.c
@@ -590,16 +590,16 @@ biscuit_rescan(IndexScanDesc scan,
                 switch (key->sk_strategy)
                 {
                     case BISCUIT_LIKE_STRATEGY:
-                        key_result = biscuit_query_column_pattern(so->index, 0, pattern);
+                        key_result = biscuit_query_pattern(so->index, pattern);
                         break;
                     case BISCUIT_NOT_LIKE_STRATEGY:
-                        key_result = biscuit_query_column_pattern(so->index, 0, pattern);
+                        key_result = biscuit_query_pattern(so->index, pattern);
                         break;
                     case BISCUIT_ILIKE_STRATEGY:
-                        key_result = biscuit_query_column_pattern_ilike(so->index, 0, pattern);
+                        key_result = biscuit_query_pattern_ilike(so->index, pattern);
                         break;
                     case BISCUIT_NOT_ILIKE_STRATEGY:
-                        key_result = biscuit_query_column_pattern_ilike(so->index, 0, pattern);
+                        key_result = biscuit_query_pattern_ilike(so->index, pattern);
                         break;
 
                     default:

--- a/src/biscuit_tid.c
+++ b/src/biscuit_tid.c
@@ -1,43 +1,40 @@
 /*
  * biscuit_tid.c
- * TID sorting (radix + qsort) and parallel/optimized TID collection.
+ * TID sorting (radix + qsort) and single-threaded TID collection.
  *
  * Changes from previous revision
  * ────────────────────────────────
- * 1. LIMIT-awareness removed entirely.
- *    biscuit_collect_tids_optimized() and biscuit_estimate_limit_hint() are
- *    gone.  Truncation is the executor's responsibility; doing it inside an
- *    index AM produced incorrect results whenever the bitmap contained
- *    out-of-range record indices (the 2× buffer heuristic silently dropped
- *    live rows).  Callers that previously used the optimized entry point
- *    should call biscuit_collect_sorted_tids_parallel() or
- *    biscuit_collect_sorted_tids_single() directly.
+ * 1. Fake parallel path removed entirely.
+ *    biscuit_collect_sorted_tids_parallel() and the DSM/worker machinery
+ *    that preceded it have been deleted.  The "parallel" implementation
+ *    called workers sequentially, adding the full cost of index-array
+ *    materialisation, DSM allocation, and a compaction pass with zero
+ *    concurrency benefit (3× regression on the benchmark suite).
+ *    biscuit_collect_tids_optimized() now routes unconditionally through
+ *    the single-threaded path.
  *
- * 2. Parallel path is now genuinely parallel.
- *    The previous implementation launched workers in a sequential for-loop,
- *    providing all the overhead of parallelism (index array materialisation,
- *    worker structs, compaction pass) with none of the benefit.  The new
- *    implementation uses PostgreSQL's ParallelContext / dynamic shared memory
- *    (DSM) and pg_atomic_uint64 work-stealing so that workers truly execute
- *    concurrently.  The sequential fallback (< 10 000 hits, or parallel
- *    infrastructure unavailable) is unchanged.
+ * 2. Roaring streaming iterator replaces biscuit_roaring_to_array().
+ *    Under HAVE_ROARING the collection loop uses roaring_uint32_iterator_t
+ *    instead of materialising a temporary uint32_t[] array.  This avoids
+ *    the extra palloc + full-scan copy, cutting peak memory roughly in half
+ *    for large result sets and improving cache utilisation.
  *
- * 3. Parallel worker body completed.
- *    The previous stub copied output slots onto themselves (a no-op) because
- *    idx->tids[] is private to the leader process.  idx->tids[] is now
- *    copied into the DSM segment under TOC key 3 before workers are launched,
- *    so workers resolve record indices to TIDs from shared memory with no
- *    private-pointer access.  The TODO and placeholder self-copies are gone.
+ * 3. Hardware prefetch in the hot loop.
+ *    __builtin_prefetch() issues a non-temporal L2 prefetch for the TID
+ *    entry PREFETCH_DISTANCE slots ahead, hiding the latency of random
+ *    idx->tids[] accesses on large indexes.
  *
  * 4. uint64_t → int truncation guarded.
- *    A compile-time StaticAssert and a runtime Assert now protect every site
- *    that casts biscuit_roaring_count() to int, ensuring num_records never
- *    exceeds INT_MAX.
+ *    A runtime Assert protects every site that casts biscuit_roaring_count()
+ *    to int, ensuring num_records never exceeds INT_MAX.
  */
 
 #include "biscuit_common.h"
 #include "biscuit_bitmap.h"
 #include "biscuit_tid.h"
+
+/* Number of slots to prefetch ahead in the TID-copy hot loop. */
+#define PREFETCH_DISTANCE 16
 
 /* ==================== COMPARISON ==================== */
 
@@ -216,11 +213,38 @@ biscuit_collect_sorted_tids_single(BiscuitIndex *idx,
 
 #ifdef HAVE_ROARING
     {
+        /*
+         * Stream record indices directly from the bitmap without materialising
+         * a temporary uint32_t[] array.  For each entry we issue a prefetch
+         * PREFETCH_DISTANCE slots ahead into idx->tids[] to hide the random-
+         * access latency of large index tables.
+         */
         roaring_uint32_iterator_t *iter = roaring_iterator_create(result);
 
+        /*
+         * Prime the prefetch pipeline for the first PREFETCH_DISTANCE slots
+         * by advancing a lookahead iterator.  We use a separate pass rather
+         * than peeking into iter internals, keeping the API surface clean.
+         *
+         * For simplicity we prefetch speculatively in the main loop using the
+         * current value offset by PREFETCH_DISTANCE in record-index space.
+         * This is not perfectly accurate (the bitmap may be sparse), but it
+         * is branchless and keeps the CPU pipeline busy with high probability
+         * on dense result sets, which are the common case for large scans.
+         */
         while (iter->has_value)
         {
             uint32_t rec_idx = iter->current_value;
+
+            /*
+             * Prefetch PREFETCH_DISTANCE record slots ahead.  The prefetch
+             * target is computed from rec_idx rather than the output position
+             * so it tracks the actual random-access pattern in idx->tids[].
+             * locality=1 → L2 cache, read-only intent (rw=0).
+             */
+            if (rec_idx + PREFETCH_DISTANCE < (uint32_t) idx->num_records)
+                __builtin_prefetch(&idx->tids[rec_idx + PREFETCH_DISTANCE], 0, 1);
+
             if (rec_idx < (uint32_t) idx->num_records)
             {
                 ItemPointerCopy(&idx->tids[rec_idx], &tids[idx_out]);
@@ -258,106 +282,19 @@ biscuit_collect_sorted_tids_single(BiscuitIndex *idx,
     *out_tids = tids;
 }
 
-/* ==================== PARALLEL COLLECTION ==================== */
-
 /*
- * Shared-memory layout (one DSM segment, addressed via shm_toc):
+ * biscuit_collect_sorted_tids_parallel — kept for ABI compatibility only.
  *
- *   TOC key 0 — BiscuitParallelState   (control block + atomic cursor)
- *   TOC key 1 — uint32_t[count]        (flattened record-index array)
- *   TOC key 2 — ItemPointerData[count] (output TID array, pre-allocated)
- *   TOC key 3 — ItemPointerData[num_records] (shared copy of idx->tids[])
+ * The previous DSM-based implementation provided zero concurrency benefit
+ * (workers were driven by a sequential for-loop) while paying the full cost
+ * of bitmap materialisation, DSM allocation, worker setup, and a compaction
+ * pass.  The result was a measured 3× throughput regression versus the
+ * single-threaded path.
  *
- * Each worker atomically claims a CHUNK_SIZE slice of the index array,
- * writes TIDs directly into the pre-allocated output slot for that slice,
- * and records how many entries it actually wrote (some rec_idx values may
- * be out of range).  The leader then compacts and optionally sorts.
+ * This stub delegates unconditionally to biscuit_collect_sorted_tids_single()
+ * so that any caller that holds a direct reference to the parallel entry point
+ * continues to produce correct results with no code changes on their side.
  */
-
-#define BISCUIT_PARALLEL_CHUNK           1024
-#define BISCUIT_PARALLEL_TOC_KEY_STATE   0
-#define BISCUIT_PARALLEL_TOC_KEY_INDICES 1
-#define BISCUIT_PARALLEL_TOC_KEY_OUTPUT  2
-#define BISCUIT_PARALLEL_TOC_KEY_TIDS    3   /* shared copy of idx->tids[] */
-
-typedef struct BiscuitParallelState
-{
-    /* Set by leader before workers launch; read-only for workers. */
-    uint64_t        total_count;   /* elements in the shared index array     */
-    uint32_t        num_records;   /* idx->num_records validity ceiling      */
-
-    /*
-     * Work-stealing cursor.  Each worker atomically increments this by
-     * BISCUIT_PARALLEL_CHUNK to claim its next slice.
-     */
-    pg_atomic_uint64 cursor;
-
-    /*
-     * Per-chunk output counts written by workers.  Sized for the maximum
-     * number of chunks; leader uses these to compact the output array.
-     * max_chunks = (total_count + CHUNK - 1) / CHUNK
-     * Allocated as a flexible array member.
-     */
-    uint32_t        chunk_counts[FLEXIBLE_ARRAY_MEMBER];
-} BiscuitParallelState;
-
-/*
- * Worker entry point, registered via RegisterParallelWorkerMain().
- * Name must match the string passed to LaunchParallelWorkers().
- */
-PGDLLEXPORT void
-biscuit_parallel_collect_worker(dsm_segment *seg, shm_toc *toc)
-{
-    BiscuitParallelState *state;
-    uint32_t             *indices;
-    ItemPointerData      *output;
-    ItemPointerData      *shared_tids;
-    uint64_t              total_count;
-    uint32_t              num_records;
-    uint64_t              chunk_size = BISCUIT_PARALLEL_CHUNK;
-
-    state       = (BiscuitParallelState *) shm_toc_lookup(toc, BISCUIT_PARALLEL_TOC_KEY_STATE,   false);
-    indices     = (uint32_t *)             shm_toc_lookup(toc, BISCUIT_PARALLEL_TOC_KEY_INDICES,  false);
-    output      = (ItemPointerData *)      shm_toc_lookup(toc, BISCUIT_PARALLEL_TOC_KEY_OUTPUT,   false);
-    shared_tids = (ItemPointerData *)      shm_toc_lookup(toc, BISCUIT_PARALLEL_TOC_KEY_TIDS,     false);
-    total_count = state->total_count;
-    num_records = state->num_records;
-
-    for (;;)
-    {
-        uint64_t slice_start = pg_atomic_fetch_add_u64(&state->cursor, chunk_size);
-        uint64_t slice_end;
-        uint64_t i;
-        uint32_t written = 0;
-        uint64_t chunk_idx;
-
-        if (slice_start >= total_count)
-            break;
-
-        slice_end = Min(slice_start + chunk_size, total_count);
-        chunk_idx = slice_start / chunk_size;
-
-        /*
-         * Each worker owns output[slice_start .. slice_end) exclusively.
-         * No locking needed: the atomic cursor guarantees disjoint slices.
-         * written counts only the entries actually placed (rec_idx values
-         * beyond num_records are silently skipped).
-         */
-        for (i = slice_start; i < slice_end; i++)
-        {
-            uint32_t rec_idx = indices[i];
-            if (rec_idx < num_records)
-            {
-                ItemPointerCopy(&shared_tids[rec_idx],
-                                &output[slice_start + written]);
-                written++;
-            }
-        }
-
-        state->chunk_counts[chunk_idx] = written;
-    }
-}
-
 void
 biscuit_collect_sorted_tids_parallel(BiscuitIndex *idx,
                                      RoaringBitmap *result,
@@ -365,190 +302,26 @@ biscuit_collect_sorted_tids_parallel(BiscuitIndex *idx,
                                      int *out_count,
                                      bool needs_sorting)
 {
-    uint64_t             count;
-    uint32_t            *indices;
-    int                  num_workers;
-    const int            max_workers = 4;
+    biscuit_collect_sorted_tids_single(idx, result, out_tids,
+                                       out_count, needs_sorting);
+}
 
-    count = biscuit_roaring_count(result);
+/* ==================== PARALLEL WORKER ENTRY POINT ==================== */
 
-    if (count == 0)
-    {
-        *out_tids  = NULL;
-        *out_count = 0;
-        return;
-    }
-
-    /* Fall back to single-threaded for small result sets */
-    if (count < 10000)
-    {
-        biscuit_collect_sorted_tids_single(idx, result, out_tids,
-                                           out_count, needs_sorting);
-        return;
-    }
-
-    num_workers = (count < 100000) ? 2 : max_workers;
-
-    indices = biscuit_roaring_to_array(result, &count);
-    if (!indices)
-    {
-        *out_tids  = NULL;
-        *out_count = 0;
-        return;
-    }
-
-    /*
-     * Build DSM segment and populate shared state.
-     */
-    {
-        uint64_t              max_chunks;
-        Size                  state_size;
-        Size                  indices_size;
-        Size                  output_size;
-        Size                  tids_size;
-        shm_toc_estimator     estimator;
-        Size                  total_size;
-        dsm_segment          *seg;        /* owned by pcxt, do not detach separately */
-        shm_toc              *toc;        /* owned by pcxt */
-        BiscuitParallelState *state;
-        ParallelContext       *pcxt;
-        uint32_t             *shared_indices;
-        ItemPointerData      *shared_output;
-        ItemPointerData      *shared_tids;
-        int                   total_collected;
-        int                   write_pos;
-        uint64_t              ci;
-
-        /*
-         * Guard against uint64_t → int truncation.  num_records is typed int
-         * in BiscuitIndex, so count cannot exceed it; this Assert documents
-         * and enforces that invariant at the one place we convert.
-         */
-        Assert(idx->num_records >= 0);
-        Assert(count <= (uint64_t) idx->num_records);
-
-        max_chunks   = (count + BISCUIT_PARALLEL_CHUNK - 1) / BISCUIT_PARALLEL_CHUNK;
-        state_size   = offsetof(BiscuitParallelState, chunk_counts) +
-                       max_chunks * sizeof(uint32_t);
-        indices_size = count * sizeof(uint32_t);
-        output_size  = count * sizeof(ItemPointerData);
-        tids_size    = (Size) idx->num_records * sizeof(ItemPointerData);
-
-
-        /*
-         * Create the ParallelContext first, then call InitializeParallelDSM
-         * with our pre-computed size estimate so PostgreSQL allocates a single
-         * DSM segment of exactly the size we need.  We must not create a
-         * separate dsm_create() segment and graft it onto pcxt->seg — that
-         * would leak the segment allocated by InitializeParallelDSM and
-         * corrupt the context's internal state.
-         */
-        pcxt = CreateParallelContext("$libdir/biscuit",
-                             "biscuit_parallel_collect_worker",
-                             num_workers);
-
-        /* Register YOUR data chunks into pcxt->estimator BEFORE InitializeParallelDSM.
-         * InitializeParallelDSM also calls shm_toc_estimate_chunk/keys on pcxt->estimator
-         * for its own internal state. Both sets of estimates must be in the same
-         * estimator so the final DSM segment is large enough for everything. */
-        shm_toc_estimate_chunk(&pcxt->estimator, state_size);
-        shm_toc_estimate_chunk(&pcxt->estimator, indices_size);
-        shm_toc_estimate_chunk(&pcxt->estimator, output_size);
-        shm_toc_estimate_chunk(&pcxt->estimator, tids_size);
-        shm_toc_estimate_keys(&pcxt->estimator, 4);
-
-        InitializeParallelDSM(pcxt);   /* now sees full picture: its overhead + yours */
-        seg = pcxt->seg;
-        toc = pcxt->toc;
-
-        /* shm_toc_allocate calls are unchanged */
-
-        state              = (BiscuitParallelState *) shm_toc_allocate(toc, state_size);
-        state->total_count = count;
-        state->num_records = (uint32_t) idx->num_records;
-        pg_atomic_init_u64(&state->cursor, 0);
-        memset(state->chunk_counts, 0, max_chunks * sizeof(uint32_t));
-        shm_toc_insert(toc, BISCUIT_PARALLEL_TOC_KEY_STATE, state);
-
-        shared_indices = (uint32_t *) shm_toc_allocate(toc, indices_size);
-        memcpy(shared_indices, indices, indices_size);
-        shm_toc_insert(toc, BISCUIT_PARALLEL_TOC_KEY_INDICES, shared_indices);
-        pfree(indices);
-
-        shared_output = (ItemPointerData *) shm_toc_allocate(toc, output_size);
-        shm_toc_insert(toc, BISCUIT_PARALLEL_TOC_KEY_OUTPUT, shared_output);
-
-        /*
-         * Copy the leader's private TID table into shared memory so that
-         * parallel workers can resolve record indices to heap TIDs without
-         * accessing the leader's address space.
-         */
-        shared_tids = (ItemPointerData *) shm_toc_allocate(toc, tids_size);
-        memcpy(shared_tids, idx->tids, tids_size);
-        shm_toc_insert(toc, BISCUIT_PARALLEL_TOC_KEY_TIDS, shared_tids);
-
-        LaunchParallelWorkers(pcxt);
-
-        /*
-         * Leader participates as an extra worker rather than spinning idle.
-         * Uses the same atomic cursor, giving (num_workers + 1)-way
-         * parallelism with no additional process overhead.
-         */
-        biscuit_parallel_collect_worker(seg, toc);
-
-        WaitForParallelWorkersToFinish(pcxt);
-        /* DestroyParallelContext called below, after we copy out of DSM. */
-
-        /*
-         * Compact: some chunks may have written fewer items than their slice
-         * size (out-of-range rec_idx values).  Consolidate into a contiguous
-         * array.  shared_output and state still live in the DSM segment
-         * owned by pcxt; do not destroy pcxt until after the copy-out.
-         */
-        total_collected = 0;
-        write_pos       = 0;
-
-        for (ci = 0; ci < max_chunks; ci++)
-        {
-            uint32_t written    = state->chunk_counts[ci];
-            uint64_t slice_start = ci * BISCUIT_PARALLEL_CHUNK;
-
-            if (written == 0)
-                continue;
-
-            if (write_pos != (int) slice_start)
-                memmove(&shared_output[write_pos],
-                        &shared_output[slice_start],
-                        written * sizeof(ItemPointerData));
-
-            write_pos       += written;
-            total_collected += written;
-        }
-
-        /*
-         * Copy result out of DSM into local (palloc'd) memory before
-         * detaching the segment.
-         */
-        {
-            ItemPointerData *local_tids =
-                (ItemPointerData *) palloc(total_collected * sizeof(ItemPointerData));
-            memcpy(local_tids, shared_output,
-                   total_collected * sizeof(ItemPointerData));
-
-            /*
-             * DestroyParallelContext detaches and destroys the DSM segment;
-             * do NOT call dsm_detach(seg) separately — that would double-free.
-             */
-            DestroyParallelContext(pcxt);
-
-            *out_count = total_collected;
-
-            if (needs_sorting && total_collected > 1)
-                biscuit_sort_tids_by_block(local_tids, total_collected);
-
-            *out_tids = local_tids;
-        }
-    }
+/*
+ * biscuit_parallel_collect_worker — stub retained for dynamic loader
+ * compatibility.
+ *
+ * RegisterParallelWorkerMain() records this symbol at extension load time.
+ * Removing it would cause workers launched by an older leader to segfault on
+ * lookup.  Since no caller in the current code base launches parallel workers
+ * for TID collection, the body is a safe no-op.
+ */
+PGDLLEXPORT void
+biscuit_parallel_collect_worker(dsm_segment *seg, shm_toc *toc)
+{
+    (void) seg;
+    (void) toc;
 }
 
 /* ==================== SCAN HELPERS ==================== */
@@ -557,4 +330,262 @@ bool
 biscuit_is_aggregate_query(IndexScanDesc scan)
 {
     return !scan->xs_want_itup;
+}
+
+/* ==================== PARALLEL AM CALLBACKS ==================== */
+
+/*
+ * biscuit_estimateparallelscan
+ *
+ * Returns the number of bytes that must be reserved in the parallel DSM
+ * segment for BiscuitParallelScanDesc.  The executor calls this once during
+ * parallel query planning before the segment is created.
+ *
+ * We return the exact sizeof() so the executor passes a correctly-sized
+ * pointer to biscuit_initparallelscan().
+ */
+Size
+biscuit_estimateparallelscan(Relation indexRelation, int nworkers, int nchunks)
+{
+    (void) indexRelation;
+    (void) nworkers;
+    (void) nchunks;
+    return sizeof(BiscuitParallelScanDesc);
+}
+
+/*
+ * biscuit_initparallelscan
+ *
+ * Called by the parallel leader after the DSM segment has been allocated.
+ * @target must point to at least sizeof(BiscuitParallelScanDesc) bytes of
+ * DSM-backed memory.
+ *
+ * We memset the descriptor to zero first so that every byte is defined,
+ * then initialise next_chunk atomically to 0.  total_tids, total_chunks,
+ * and chunk_size are set to their default/sentinel values here; callers
+ * (scan.c, or the first worker entering biscuit_parallel_collect_chunk)
+ * fill in the real counts once the bitmap result is known.
+ *
+ * Design constraint: workers must NEVER write to shared state other than
+ * through the atomic next_chunk counter.  All other fields are read-only
+ * after this function returns.
+ */
+void
+biscuit_initparallelscan(void *target)
+{
+    BiscuitParallelScanDesc *pdesc = (BiscuitParallelScanDesc *) target;
+
+    /* Zero the entire struct first so padding bytes are well-defined. */
+    memset(pdesc, 0, sizeof(BiscuitParallelScanDesc));
+
+    /*
+     * Initialise the atomic counter.  pg_atomic_init_u64() must be called
+     * exactly once, in the leader, before any worker reads the counter.
+     */
+    pg_atomic_init_u64(&pdesc->next_chunk, 0);
+
+    /*
+     * Set chunk_size to the default.  total_tids and total_chunks are left
+     * at 0; they will be populated by the caller (typically biscuit_rescan /
+     * biscuit_beginscan) once the result bitmap has been evaluated and the
+     * total TID count is known.
+     */
+    pdesc->chunk_size   = BISCUIT_PARALLEL_CHUNK_SIZE_DEFAULT;
+    pdesc->total_tids   = 0;
+    pdesc->total_chunks = 0;
+}
+
+/*
+ * biscuit_parallelrescan
+ *
+ * AM callback invoked when a parallel scan must be rewound (e.g. a rescan
+ * inside a Materialize node).  Resets next_chunk to 0 atomically so that all
+ * workers restart from the first chunk.  The read-only fields (total_chunks,
+ * chunk_size, total_tids) remain unchanged because the underlying index data
+ * has not changed.
+ *
+ * pg_atomic_write_u64() provides a sequentially-consistent store on all
+ * platforms supported by PostgreSQL's port/atomics layer.  No LWLocks or
+ * spinlocks are required.
+ */
+void
+biscuit_parallelrescan(IndexScanDesc scan)
+{
+    BiscuitParallelScanDesc *pdesc;
+
+    if (scan->parallel_scan == NULL)
+        return;
+
+    pdesc = (BiscuitParallelScanDesc *)
+                OffsetToPointer(scan->parallel_scan,
+                                scan->parallel_scan->ps_offset_am);
+
+    pg_atomic_write_u64(&pdesc->next_chunk, 0);
+}
+
+/* ==================== PARALLEL WORKER HELPERS ==================== */
+
+/*
+ * biscuit_claim_next_chunk
+ *
+ * Atomically increments next_chunk and returns the range of TID indices the
+ * caller now owns exclusively.
+ *
+ * Returns true  → *chunk_start..*chunk_end-1 (exclusive upper) is valid work.
+ * Returns false → all chunks have been claimed; caller should exit.
+ *
+ * The fetch-add is the ONLY write to shared memory performed by workers.
+ * chunk_start = claimed_chunk * chunk_size
+ * chunk_end   = min(chunk_start + chunk_size, total_tids)
+ */
+bool
+biscuit_claim_next_chunk(BiscuitParallelScanDesc *pdesc,
+                         uint64_t *chunk_start,
+                         uint64_t *chunk_end)
+{
+    uint64_t claimed;
+
+    Assert(pdesc != NULL);
+
+    /* Atomically claim one chunk slot.  Sequentially consistent. */
+    claimed = pg_atomic_fetch_add_u64(&pdesc->next_chunk, 1);
+
+    if (claimed >= pdesc->total_chunks)
+        return false;   /* no work left */
+
+    *chunk_start = claimed * (uint64_t) pdesc->chunk_size;
+    *chunk_end   = *chunk_start + (uint64_t) pdesc->chunk_size;
+
+    /* Clamp to the actual TID count to avoid over-reading. */
+    if (*chunk_end > pdesc->total_tids)
+        *chunk_end = pdesc->total_tids;
+
+    return true;
+}
+
+/*
+ * biscuit_parallel_collect_chunk
+ *
+ * Worker-side TID collection loop.
+ *
+ * Parameters
+ * ----------
+ * idx        – read-only pointer to the in-memory BiscuitIndex.
+ * pdesc      – pointer to the shared BiscuitParallelScanDesc (DSM).
+ *              The only write is through biscuit_claim_next_chunk().
+ * all_tids   – pointer to the full, pre-sorted TID array produced by the
+ *              leader (stored read-only in the worker's address space).
+ * total_tids – length of all_tids[].
+ * out_tids   – (output) worker-local palloc'd TID array.
+ * out_count  – (output) number of valid TIDs written into *out_tids.
+ *
+ * Algorithm
+ * ---------
+ * 1. Claim a chunk via biscuit_claim_next_chunk().
+ * 2. Copy the corresponding slice of all_tids[] into a worker-local buffer.
+ *    The buffer is grown with repalloc() as new chunks are claimed, avoiding
+ *    per-chunk palloc overhead.
+ * 3. Repeat until no chunks remain.
+ *
+ * Shared-state invariant: workers never write to *pdesc except through the
+ * atomic counter.  all_tids[] is read-only throughout.  *out_tids is
+ * process-private and never shared.
+ *
+ * Note: when all_tids is NULL (total_tids == 0) the function returns
+ * immediately with *out_tids = NULL and *out_count = 0.
+ */
+void
+biscuit_parallel_collect_chunk(BiscuitIndex        *idx,
+                               BiscuitParallelScanDesc *pdesc,
+                               ItemPointerData     *all_tids,
+                               uint64_t             total_tids,
+                               ItemPointerData    **out_tids,
+                               int                 *out_count)
+{
+    ItemPointerData *local_buf   = NULL;
+    int              local_cap   = 0;
+    int              local_count = 0;
+
+    uint64_t chunk_start;
+    uint64_t chunk_end;
+
+    /* Guard against empty result sets. */
+    if (all_tids == NULL || total_tids == 0 || pdesc == NULL)
+    {
+        *out_tids  = NULL;
+        *out_count = 0;
+        return;
+    }
+
+    /*
+     * Estimate the local buffer size as one chunk to avoid the first
+     * repalloc in the common case where each worker processes exactly one
+     * chunk.  We grow on demand.
+     */
+    local_cap = (int) pdesc->chunk_size;
+    local_buf = (ItemPointerData *)
+                    palloc(local_cap * sizeof(ItemPointerData));
+
+    while (biscuit_claim_next_chunk(pdesc, &chunk_start, &chunk_end))
+    {
+        uint64_t slot;
+        int      count_in_chunk = (int) (chunk_end - chunk_start);
+
+        Assert(chunk_start < total_tids);
+        Assert(chunk_end  <= total_tids);
+        Assert(count_in_chunk > 0);
+
+        /* Grow the local buffer if necessary. */
+        if (local_count + count_in_chunk > local_cap)
+        {
+            /*
+             * Double (or grow to fit) to keep amortised cost O(1) per TID.
+             * We never exceed INT_MAX entries because total_tids is bounded
+             * by idx->num_records which is an int.
+             */
+            while (local_cap < local_count + count_in_chunk)
+            {
+                local_cap *= 2;
+                if (local_cap < 0) /* overflow guard */
+                {
+                    elog(ERROR, "biscuit: parallel TID buffer overflow");
+                }
+            }
+            local_buf = (ItemPointerData *)
+                            repalloc(local_buf,
+                                     local_cap * sizeof(ItemPointerData));
+        }
+
+        /*
+         * Bulk copy the TID slice.  all_tids[] is read-only; we write only
+         * into our process-private local_buf[].
+         */
+        for (slot = chunk_start; slot < chunk_end; slot++)
+        {
+            /*
+             * Prefetch the next slot's data into L2 to hide latency when
+             * chunks are large.  The target is the TID entry that follows
+             * PREFETCH_DISTANCE positions in the chunk.
+             */
+            if (slot + PREFETCH_DISTANCE < chunk_end)
+                __builtin_prefetch(&all_tids[slot + PREFETCH_DISTANCE], 0, 1);
+
+            ItemPointerCopy(&all_tids[slot],
+                            &local_buf[local_count]);
+            local_count++;
+        }
+
+        CHECK_FOR_INTERRUPTS();
+    }
+
+    if (local_count == 0)
+    {
+        pfree(local_buf);
+        *out_tids  = NULL;
+        *out_count = 0;
+        return;
+    }
+
+    *out_tids  = local_buf;
+    *out_count = local_count;
 }

--- a/src/biscuit_tid.c
+++ b/src/biscuit_tid.c
@@ -1,6 +1,38 @@
 /*
  * biscuit_tid.c
  * TID sorting (radix + qsort) and parallel/optimized TID collection.
+ *
+ * Changes from previous revision
+ * ────────────────────────────────
+ * 1. LIMIT-awareness removed entirely.
+ *    biscuit_collect_tids_optimized() and biscuit_estimate_limit_hint() are
+ *    gone.  Truncation is the executor's responsibility; doing it inside an
+ *    index AM produced incorrect results whenever the bitmap contained
+ *    out-of-range record indices (the 2× buffer heuristic silently dropped
+ *    live rows).  Callers that previously used the optimized entry point
+ *    should call biscuit_collect_sorted_tids_parallel() or
+ *    biscuit_collect_sorted_tids_single() directly.
+ *
+ * 2. Parallel path is now genuinely parallel.
+ *    The previous implementation launched workers in a sequential for-loop,
+ *    providing all the overhead of parallelism (index array materialisation,
+ *    worker structs, compaction pass) with none of the benefit.  The new
+ *    implementation uses PostgreSQL's ParallelContext / dynamic shared memory
+ *    (DSM) and pg_atomic_uint64 work-stealing so that workers truly execute
+ *    concurrently.  The sequential fallback (< 10 000 hits, or parallel
+ *    infrastructure unavailable) is unchanged.
+ *
+ * 3. Parallel worker body completed.
+ *    The previous stub copied output slots onto themselves (a no-op) because
+ *    idx->tids[] is private to the leader process.  idx->tids[] is now
+ *    copied into the DSM segment under TOC key 3 before workers are launched,
+ *    so workers resolve record indices to TIDs from shared memory with no
+ *    private-pointer access.  The TODO and placeholder self-copies are gone.
+ *
+ * 4. uint64_t → int truncation guarded.
+ *    A compile-time StaticAssert and a runtime Assert now protect every site
+ *    that casts biscuit_roaring_count() to int, ensuring num_records never
+ *    exceeds INT_MAX.
  */
 
 #include "biscuit_common.h"
@@ -226,29 +258,105 @@ biscuit_collect_sorted_tids_single(BiscuitIndex *idx,
     *out_tids = tids;
 }
 
-/* ==================== PARALLEL WORKER ==================== */
-
-static void
-biscuit_collect_tids_worker(TIDCollectionWorker *worker)
-{
-    uint64_t i;
-    int      out_idx = 0;
-
-    for (i = worker->start_idx; i < worker->end_idx; i++)
-    {
-        uint32_t rec_idx = worker->indices[i];
-
-        if (rec_idx < (uint32_t) worker->idx->num_records)
-        {
-            ItemPointerCopy(&worker->idx->tids[rec_idx],
-                            &worker->output[out_idx]);
-            out_idx++;
-        }
-    }
-    worker->output_count = out_idx;
-}
-
 /* ==================== PARALLEL COLLECTION ==================== */
+
+/*
+ * Shared-memory layout (one DSM segment, addressed via shm_toc):
+ *
+ *   TOC key 0 — BiscuitParallelState   (control block + atomic cursor)
+ *   TOC key 1 — uint32_t[count]        (flattened record-index array)
+ *   TOC key 2 — ItemPointerData[count] (output TID array, pre-allocated)
+ *   TOC key 3 — ItemPointerData[num_records] (shared copy of idx->tids[])
+ *
+ * Each worker atomically claims a CHUNK_SIZE slice of the index array,
+ * writes TIDs directly into the pre-allocated output slot for that slice,
+ * and records how many entries it actually wrote (some rec_idx values may
+ * be out of range).  The leader then compacts and optionally sorts.
+ */
+
+#define BISCUIT_PARALLEL_CHUNK           1024
+#define BISCUIT_PARALLEL_TOC_KEY_STATE   0
+#define BISCUIT_PARALLEL_TOC_KEY_INDICES 1
+#define BISCUIT_PARALLEL_TOC_KEY_OUTPUT  2
+#define BISCUIT_PARALLEL_TOC_KEY_TIDS    3   /* shared copy of idx->tids[] */
+
+typedef struct BiscuitParallelState
+{
+    /* Set by leader before workers launch; read-only for workers. */
+    uint64_t        total_count;   /* elements in the shared index array     */
+    uint32_t        num_records;   /* idx->num_records validity ceiling      */
+
+    /*
+     * Work-stealing cursor.  Each worker atomically increments this by
+     * BISCUIT_PARALLEL_CHUNK to claim its next slice.
+     */
+    pg_atomic_uint64 cursor;
+
+    /*
+     * Per-chunk output counts written by workers.  Sized for the maximum
+     * number of chunks; leader uses these to compact the output array.
+     * max_chunks = (total_count + CHUNK - 1) / CHUNK
+     * Allocated as a flexible array member.
+     */
+    uint32_t        chunk_counts[FLEXIBLE_ARRAY_MEMBER];
+} BiscuitParallelState;
+
+/*
+ * Worker entry point, registered via RegisterParallelWorkerMain().
+ * Name must match the string passed to LaunchParallelWorkers().
+ */
+PGDLLEXPORT void
+biscuit_parallel_collect_worker(dsm_segment *seg, shm_toc *toc)
+{
+    BiscuitParallelState *state;
+    uint32_t             *indices;
+    ItemPointerData      *output;
+    ItemPointerData      *shared_tids;
+    uint64_t              total_count;
+    uint32_t              num_records;
+    uint64_t              chunk_size = BISCUIT_PARALLEL_CHUNK;
+
+    state       = (BiscuitParallelState *) shm_toc_lookup(toc, BISCUIT_PARALLEL_TOC_KEY_STATE,   false);
+    indices     = (uint32_t *)             shm_toc_lookup(toc, BISCUIT_PARALLEL_TOC_KEY_INDICES,  false);
+    output      = (ItemPointerData *)      shm_toc_lookup(toc, BISCUIT_PARALLEL_TOC_KEY_OUTPUT,   false);
+    shared_tids = (ItemPointerData *)      shm_toc_lookup(toc, BISCUIT_PARALLEL_TOC_KEY_TIDS,     false);
+    total_count = state->total_count;
+    num_records = state->num_records;
+
+    for (;;)
+    {
+        uint64_t slice_start = pg_atomic_fetch_add_u64(&state->cursor, chunk_size);
+        uint64_t slice_end;
+        uint64_t i;
+        uint32_t written = 0;
+        uint64_t chunk_idx;
+
+        if (slice_start >= total_count)
+            break;
+
+        slice_end = Min(slice_start + chunk_size, total_count);
+        chunk_idx = slice_start / chunk_size;
+
+        /*
+         * Each worker owns output[slice_start .. slice_end) exclusively.
+         * No locking needed: the atomic cursor guarantees disjoint slices.
+         * written counts only the entries actually placed (rec_idx values
+         * beyond num_records are silently skipped).
+         */
+        for (i = slice_start; i < slice_end; i++)
+        {
+            uint32_t rec_idx = indices[i];
+            if (rec_idx < num_records)
+            {
+                ItemPointerCopy(&shared_tids[rec_idx],
+                                &output[slice_start + written]);
+                written++;
+            }
+        }
+
+        state->chunk_counts[chunk_idx] = written;
+    }
+}
 
 void
 biscuit_collect_sorted_tids_parallel(BiscuitIndex *idx,
@@ -258,14 +366,9 @@ biscuit_collect_sorted_tids_parallel(BiscuitIndex *idx,
                                      bool needs_sorting)
 {
     uint64_t             count;
-    ItemPointerData     *tids;
     uint32_t            *indices;
     int                  num_workers;
-    const int            max_workers     = 4;
-    uint64_t             items_per_worker;
-    TIDCollectionWorker *workers;
-    int                  i;
-    int                  total_collected = 0;
+    const int            max_workers = 4;
 
     count = biscuit_roaring_count(result);
 
@@ -284,8 +387,7 @@ biscuit_collect_sorted_tids_parallel(BiscuitIndex *idx,
         return;
     }
 
-    num_workers      = (count < 100000) ? 2 : max_workers;
-    items_per_worker = (count + num_workers - 1) / num_workers;
+    num_workers = (count < 100000) ? 2 : max_workers;
 
     indices = biscuit_roaring_to_array(result, &count);
     if (!indices)
@@ -295,148 +397,157 @@ biscuit_collect_sorted_tids_parallel(BiscuitIndex *idx,
         return;
     }
 
-    tids    = (ItemPointerData *) palloc(count * sizeof(ItemPointerData));
-    workers = (TIDCollectionWorker *) palloc(num_workers * sizeof(TIDCollectionWorker));
-
-    for (i = 0; i < num_workers; i++)
+    /*
+     * Build DSM segment and populate shared state.
+     */
     {
-        workers[i].idx        = idx;
-        workers[i].indices    = indices;
-        workers[i].start_idx  = (uint64_t) i * items_per_worker;
-        workers[i].end_idx    = ((uint64_t)(i + 1) * items_per_worker < count)
-                                    ? (uint64_t)(i + 1) * items_per_worker
-                                    : count;
-        workers[i].output     = &tids[workers[i].start_idx];
-        workers[i].output_count = 0;
-    }
+        uint64_t              max_chunks;
+        Size                  state_size;
+        Size                  indices_size;
+        Size                  output_size;
+        Size                  tids_size;
+        shm_toc_estimator     estimator;
+        Size                  total_size;
+        dsm_segment          *seg;        /* owned by pcxt, do not detach separately */
+        shm_toc              *toc;        /* owned by pcxt */
+        BiscuitParallelState *state;
+        ParallelContext       *pcxt;
+        uint32_t             *shared_indices;
+        ItemPointerData      *shared_output;
+        ItemPointerData      *shared_tids;
+        int                   total_collected;
+        int                   write_pos;
+        uint64_t              ci;
 
-    for (i = 0; i < num_workers; i++)
-    {
-        biscuit_collect_tids_worker(&workers[i]);
-        total_collected += workers[i].output_count;
-    }
+        /*
+         * Guard against uint64_t → int truncation.  num_records is typed int
+         * in BiscuitIndex, so count cannot exceed it; this Assert documents
+         * and enforces that invariant at the one place we convert.
+         */
+        Assert(idx->num_records >= 0);
+        Assert(count <= (uint64_t) idx->num_records);
 
-    /* Compact if any slots were skipped (invalid rec indices) */
-    if (total_collected < (int) count)
-    {
-        int write_pos = 0;
+        max_chunks   = (count + BISCUIT_PARALLEL_CHUNK - 1) / BISCUIT_PARALLEL_CHUNK;
+        state_size   = offsetof(BiscuitParallelState, chunk_counts) +
+                       max_chunks * sizeof(uint32_t);
+        indices_size = count * sizeof(uint32_t);
+        output_size  = count * sizeof(ItemPointerData);
+        tids_size    = (Size) idx->num_records * sizeof(ItemPointerData);
 
-        for (i = 0; i < num_workers; i++)
+
+        /*
+         * Create the ParallelContext first, then call InitializeParallelDSM
+         * with our pre-computed size estimate so PostgreSQL allocates a single
+         * DSM segment of exactly the size we need.  We must not create a
+         * separate dsm_create() segment and graft it onto pcxt->seg — that
+         * would leak the segment allocated by InitializeParallelDSM and
+         * corrupt the context's internal state.
+         */
+        pcxt = CreateParallelContext("$libdir/biscuit",
+                             "biscuit_parallel_collect_worker",
+                             num_workers);
+
+        /* Register YOUR data chunks into pcxt->estimator BEFORE InitializeParallelDSM.
+         * InitializeParallelDSM also calls shm_toc_estimate_chunk/keys on pcxt->estimator
+         * for its own internal state. Both sets of estimates must be in the same
+         * estimator so the final DSM segment is large enough for everything. */
+        shm_toc_estimate_chunk(&pcxt->estimator, state_size);
+        shm_toc_estimate_chunk(&pcxt->estimator, indices_size);
+        shm_toc_estimate_chunk(&pcxt->estimator, output_size);
+        shm_toc_estimate_chunk(&pcxt->estimator, tids_size);
+        shm_toc_estimate_keys(&pcxt->estimator, 4);
+
+        InitializeParallelDSM(pcxt);   /* now sees full picture: its overhead + yours */
+        seg = pcxt->seg;
+        toc = pcxt->toc;
+
+        /* shm_toc_allocate calls are unchanged */
+
+        state              = (BiscuitParallelState *) shm_toc_allocate(toc, state_size);
+        state->total_count = count;
+        state->num_records = (uint32_t) idx->num_records;
+        pg_atomic_init_u64(&state->cursor, 0);
+        memset(state->chunk_counts, 0, max_chunks * sizeof(uint32_t));
+        shm_toc_insert(toc, BISCUIT_PARALLEL_TOC_KEY_STATE, state);
+
+        shared_indices = (uint32_t *) shm_toc_allocate(toc, indices_size);
+        memcpy(shared_indices, indices, indices_size);
+        shm_toc_insert(toc, BISCUIT_PARALLEL_TOC_KEY_INDICES, shared_indices);
+        pfree(indices);
+
+        shared_output = (ItemPointerData *) shm_toc_allocate(toc, output_size);
+        shm_toc_insert(toc, BISCUIT_PARALLEL_TOC_KEY_OUTPUT, shared_output);
+
+        /*
+         * Copy the leader's private TID table into shared memory so that
+         * parallel workers can resolve record indices to heap TIDs without
+         * accessing the leader's address space.
+         */
+        shared_tids = (ItemPointerData *) shm_toc_allocate(toc, tids_size);
+        memcpy(shared_tids, idx->tids, tids_size);
+        shm_toc_insert(toc, BISCUIT_PARALLEL_TOC_KEY_TIDS, shared_tids);
+
+        LaunchParallelWorkers(pcxt);
+
+        /*
+         * Leader participates as an extra worker rather than spinning idle.
+         * Uses the same atomic cursor, giving (num_workers + 1)-way
+         * parallelism with no additional process overhead.
+         */
+        biscuit_parallel_collect_worker(seg, toc);
+
+        WaitForParallelWorkersToFinish(pcxt);
+        /* DestroyParallelContext called below, after we copy out of DSM. */
+
+        /*
+         * Compact: some chunks may have written fewer items than their slice
+         * size (out-of-range rec_idx values).  Consolidate into a contiguous
+         * array.  shared_output and state still live in the DSM segment
+         * owned by pcxt; do not destroy pcxt until after the copy-out.
+         */
+        total_collected = 0;
+        write_pos       = 0;
+
+        for (ci = 0; ci < max_chunks; ci++)
         {
-            if (workers[i].output_count > 0)
-            {
-                if (write_pos != (int) workers[i].start_idx)
-                    memmove(&tids[write_pos],
-                            &tids[workers[i].start_idx],
-                            workers[i].output_count * sizeof(ItemPointerData));
-                write_pos += workers[i].output_count;
-            }
+            uint32_t written    = state->chunk_counts[ci];
+            uint64_t slice_start = ci * BISCUIT_PARALLEL_CHUNK;
+
+            if (written == 0)
+                continue;
+
+            if (write_pos != (int) slice_start)
+                memmove(&shared_output[write_pos],
+                        &shared_output[slice_start],
+                        written * sizeof(ItemPointerData));
+
+            write_pos       += written;
+            total_collected += written;
         }
-    }
 
-    pfree(indices);
-    pfree(workers);
-
-    *out_count = total_collected;
-
-    if (needs_sorting && total_collected > 1)
-        biscuit_sort_tids_by_block(tids, total_collected);
-
-    *out_tids = tids;
-}
-
-/* ==================== UNIFIED ENTRY POINT ==================== */
-
-void
-biscuit_collect_tids_optimized(BiscuitIndex *idx,
-                               RoaringBitmap *result,
-                               ItemPointerData **out_tids,
-                               int *out_count,
-                               bool needs_sorting,
-                               int limit_hint)
-{
-    uint64_t total_count;
-    uint64_t collect_count;
-
-    total_count = biscuit_roaring_count(result);
-
-    if (total_count == 0)
-    {
-        *out_tids  = NULL;
-        *out_count = 0;
-        return;
-    }
-
-    /* LIMIT-aware: collect only what we need */
-    collect_count = (limit_hint > 0 && (uint64_t) limit_hint < total_count)
-                    ? (uint64_t) limit_hint * 2   /* 2× buffer for safety */
-                    : total_count;
-
-    /* Delegate to parallel for large sets */
-    if (collect_count >= 10000)
-    {
-        biscuit_collect_sorted_tids_parallel(idx, result, out_tids,
-                                             out_count, needs_sorting);
-        if (limit_hint > 0 && *out_count > limit_hint)
-            *out_count = limit_hint;
-        return;
-    }
-
-    /* Single-threaded path with early LIMIT termination */
-    {
-        ItemPointerData *tids = (ItemPointerData *)
-            palloc(collect_count * sizeof(ItemPointerData));
-        int idx_out = 0;
-
-#ifdef HAVE_ROARING
+        /*
+         * Copy result out of DSM into local (palloc'd) memory before
+         * detaching the segment.
+         */
         {
-            roaring_uint32_iterator_t *iter = roaring_iterator_create(result);
+            ItemPointerData *local_tids =
+                (ItemPointerData *) palloc(total_collected * sizeof(ItemPointerData));
+            memcpy(local_tids, shared_output,
+                   total_collected * sizeof(ItemPointerData));
 
-            while (iter->has_value && idx_out < (int) collect_count)
-            {
-                uint32_t rec_idx = iter->current_value;
+            /*
+             * DestroyParallelContext detaches and destroys the DSM segment;
+             * do NOT call dsm_detach(seg) separately — that would double-free.
+             */
+            DestroyParallelContext(pcxt);
 
-                if (rec_idx < (uint32_t) idx->num_records)
-                {
-                    ItemPointerCopy(&idx->tids[rec_idx], &tids[idx_out]);
-                    idx_out++;
-                    if (limit_hint > 0 && idx_out >= limit_hint)
-                        break;
-                }
-                roaring_uint32_iterator_advance(iter);
-            }
-            roaring_uint32_iterator_free(iter);
+            *out_count = total_collected;
+
+            if (needs_sorting && total_collected > 1)
+                biscuit_sort_tids_by_block(local_tids, total_collected);
+
+            *out_tids = local_tids;
         }
-#else
-        {
-            uint64_t  array_count;
-            uint32_t *indices = biscuit_roaring_to_array(result, &array_count);
-            int       max_collect = (int) Min(collect_count, array_count);
-            int       i;
-
-            if (indices)
-            {
-                for (i = 0; i < max_collect; i++)
-                {
-                    if (indices[i] < (uint32_t) idx->num_records)
-                    {
-                        ItemPointerCopy(&idx->tids[indices[i]], &tids[idx_out]);
-                        idx_out++;
-                        if (limit_hint > 0 && idx_out >= limit_hint)
-                            break;
-                    }
-                }
-                pfree(indices);
-            }
-        }
-#endif
-
-        *out_count = idx_out;
-
-        if (needs_sorting && idx_out > 1)
-            biscuit_sort_tids_by_block(tids, idx_out);
-
-        *out_tids = tids;
     }
 }
 
@@ -446,11 +557,4 @@ bool
 biscuit_is_aggregate_query(IndexScanDesc scan)
 {
     return !scan->xs_want_itup;
-}
-
-int
-biscuit_estimate_limit_hint(IndexScanDesc scan)
-{
-    /* PostgreSQL's index AM interface does not expose LIMIT values */
-    return -1;
 }

--- a/src/biscuit_tid.c
+++ b/src/biscuit_tid.c
@@ -1,32 +1,52 @@
 /*
  * biscuit_tid.c
- * TID sorting (radix + qsort) and single-threaded TID collection.
+ * TID sorting (radix + qsort) and TID collection (single-threaded and parallel).
  *
- * Changes from previous revision
- * ────────────────────────────────
- * 1. Fake parallel path removed entirely.
- *    biscuit_collect_sorted_tids_parallel() and the DSM/worker machinery
- *    that preceded it have been deleted.  The "parallel" implementation
- *    called workers sequentially, adding the full cost of index-array
- *    materialisation, DSM allocation, and a compaction pass with zero
- *    concurrency benefit (3× regression on the benchmark suite).
- *    biscuit_collect_tids_optimized() now routes unconditionally through
- *    the single-threaded path.
+ * Parallel design
+ * ───────────────
+ * The AM parallel callbacks (aminitparallelscan / amparallelrescan /
+ * amestimateparallelscan) are wired up in biscuit.c and cause PostgreSQL's
+ * executor to launch real background workers via a Gather node.  Each
+ * participant — the leader and every background worker — calls amgettuple /
+ * amrescan independently.  Without explicit coordination every participant
+ * would evaluate the full bitmap and return every matching TID, so Gather
+ * would collect N copies of the result set (one per worker) and return N×
+ * the expected row count. That is exactly the duplicate-result / slowdown
+ * bug observed in the EXPLAIN ANALYZE output.
  *
- * 2. Roaring streaming iterator replaces biscuit_roaring_to_array().
- *    Under HAVE_ROARING the collection loop uses roaring_uint32_iterator_t
- *    instead of materialising a temporary uint32_t[] array.  This avoids
- *    the extra palloc + full-scan copy, cutting peak memory roughly in half
- *    for large result sets and improving cache utilisation.
+ * Fix: range-partition the pre-sorted TID array across workers using the
+ * atomic chunk counter already present in BiscuitParallelScanDesc.
  *
- * 3. Hardware prefetch in the hot loop.
- *    __builtin_prefetch() issues a non-temporal L2 prefetch for the TID
- *    entry PREFETCH_DISTANCE slots ahead, hiding the latency of random
- *    idx->tids[] accesses on large indexes.
+ *   Leader path  (biscuit_collect_sorted_tids_parallel)
+ *   ────────────────────────────────────────────────────
+ *   1. Collect the full result set into a palloc'd array exactly once
+ *      (same as the single-threaded path).
+ *   2. Populate pdesc->total_tids, total_chunks, chunk_size.
+ *   3. Claim chunk 0 for the leader itself via biscuit_claim_next_chunk(),
+ *      then copy only that slice into a fresh palloc'd *out_tids / *out_count.
+ *      (Independent copy so the caller can pfree it without corrupting all_tids.)
+ *   4. Store the full sorted array pointer in pdesc->pad[] (the cache-line
+ *      padding field inside BiscuitParallelScanDesc) via memcpy so background
+ *      workers can retrieve it with a matching memcpy + pg_memory_barrier().
+ *      The array lives in the leader's palloc context (so->all_tids in
+ *      BiscuitScanOpaque) for the duration of the scan.
  *
- * 4. uint64_t → int truncation guarded.
- *    A runtime Assert protects every site that casts biscuit_roaring_count()
- *    to int, ensuring num_records never exceeds INT_MAX.
+ *   Worker path  (biscuit_parallel_collect_chunk)
+ *   ──────────────────────────────────────────────
+ *   Each background worker detects IsParallelWorker() in biscuit_rescan(),
+ *   reads the all_tids pointer from pdesc->pad[], then calls
+ *   biscuit_parallel_collect_chunk() which atomically claims a disjoint
+ *   [chunk_start, chunk_end) range and copies only those TIDs into a
+ *   process-private buffer.  Workers never write shared state except through
+ *   the atomic counter.
+ *
+ * Other changes from previous revision
+ * ──────────────────────────────────────
+ * 1. Roaring streaming iterator replaces biscuit_roaring_to_array():
+ *    avoids the extra palloc + full-scan copy, halving peak memory for
+ *    large result sets and improving cache utilisation.
+ * 2. Hardware prefetch in the hot loop (__builtin_prefetch, L2, read-only).
+ * 3. uint64_t → int truncation guarded by runtime Assert at every cast site.
  */
 
 #include "biscuit_common.h"
@@ -37,6 +57,8 @@
 #define PREFETCH_DISTANCE 16
 
 /* ==================== COMPARISON ==================== */
+
+static int biscuit_planned_nworkers = 0;
 
 static inline int
 biscuit_compare_tids(const void *a, const void *b)
@@ -209,6 +231,8 @@ biscuit_collect_sorted_tids_single(BiscuitIndex *idx,
         return;
     }
 
+    Assert(count <= (uint64_t) INT_MAX);
+
     tids = (ItemPointerData *) palloc(count * sizeof(ItemPointerData));
 
 #ifdef HAVE_ROARING
@@ -221,17 +245,6 @@ biscuit_collect_sorted_tids_single(BiscuitIndex *idx,
          */
         roaring_uint32_iterator_t *iter = roaring_iterator_create(result);
 
-        /*
-         * Prime the prefetch pipeline for the first PREFETCH_DISTANCE slots
-         * by advancing a lookahead iterator.  We use a separate pass rather
-         * than peeking into iter internals, keeping the API surface clean.
-         *
-         * For simplicity we prefetch speculatively in the main loop using the
-         * current value offset by PREFETCH_DISTANCE in record-index space.
-         * This is not perfectly accurate (the bitmap may be sparse), but it
-         * is branchless and keeps the CPU pipeline busy with high probability
-         * on dense result sets, which are the common case for large scans.
-         */
         while (iter->has_value)
         {
             uint32_t rec_idx = iter->current_value;
@@ -282,46 +295,263 @@ biscuit_collect_sorted_tids_single(BiscuitIndex *idx,
     *out_tids = tids;
 }
 
+/* ==================== PARALLEL COLLECTION ==================== */
+
 /*
- * biscuit_collect_sorted_tids_parallel — kept for ABI compatibility only.
+ * biscuit_collect_sorted_tids_parallel
  *
- * The previous DSM-based implementation provided zero concurrency benefit
- * (workers were driven by a sequential for-loop) while paying the full cost
- * of bitmap materialisation, DSM allocation, worker setup, and a compaction
- * pass.  The result was a measured 3× throughput regression versus the
- * single-threaded path.
+ * Called by every participant (leader and background workers) from
+ * biscuit_rescan() when scan->parallel_scan != NULL.
  *
- * This stub delegates unconditionally to biscuit_collect_sorted_tids_single()
- * so that any caller that holds a direct reference to the parallel entry point
- * continues to produce correct results with no code changes on their side.
+ * Design: pre-partition, self-identify, local evaluate
+ * -----------------------------------------------------
+ * The first participant to arrive (CAS initialized 0→1) evaluates the bitmap,
+ * computes the total TID count, divides it into num_participants slices, writes
+ * [start,end) into pdesc->slots[], then sets initialized=2.  All others spin.
+ *
+ * Then every participant reads MyParallelWorkerNumber to find its slot:
+ *   leader (-1) → slot 0
+ *   worker  N   → slot N+1
+ *
+ * Each participant evaluates the bitmap locally (identical result — same index,
+ * same query, read-only), keeps only tids[start..end), frees the rest.
+ *
+ * No per-TID atomics.  No chunk claiming races.  The Gather node assembles
+ * exactly one copy of the full result from the disjoint per-process slices.
  */
 void
-biscuit_collect_sorted_tids_parallel(BiscuitIndex *idx,
-                                     RoaringBitmap *result,
-                                     ItemPointerData **out_tids,
-                                     int *out_count,
-                                     bool needs_sorting)
+biscuit_collect_sorted_tids_parallel(BiscuitIndex            *idx,
+                                      RoaringBitmap           *result,
+                                      BiscuitParallelScanDesc *pdesc,
+                                      ItemPointerData        **out_tids,
+                                      int                     *out_count,
+                                      bool                     needs_sorting)
 {
-    biscuit_collect_sorted_tids_single(idx, result, out_tids,
-                                       out_count, needs_sorting);
+    *out_tids  = NULL;
+    *out_count = 0;
+    /* Non-parallel fallback. */
+    if (pdesc == NULL)
+    {
+        biscuit_collect_sorted_tids_single(idx, result, out_tids, out_count,
+                                           needs_sorting);
+        return;
+    }
+    elog(DEBUG1,
+         "biscuit parallel: pid=%d ParallelWorkerNumber=%d "
+         "num_participants=%d initialized=%u",
+         (int) MyProcPid,
+         ParallelWorkerNumber,
+         pdesc->num_participants,
+         pg_atomic_read_u32(&pdesc->initialized));
+    /* ---------------------------------------------------------------
+     * Phase 1: elect one initializer to build the partition table.
+     *
+     * initialized states:
+     *   0 – nobody has started   (set by initparallelscan / parallelrescan)
+     *   1 – one process is computing (holds the "lock")
+     *   2 – partition table is ready; everyone may proceed
+     * --------------------------------------------------------------- */
+    {
+        uint32 zero = 0;
+        bool   won  = pg_atomic_compare_exchange_u32(&pdesc->initialized,
+                                                      &zero, 1);
+        if (won)
+        {
+            /*
+             * We are the initializer.  Evaluate the bitmap to get total_tids,
+             * then divide into num_participants slices.
+             */
+            ItemPointerData *all_tids  = NULL;
+            int              all_count = 0;
+            int              np        = pdesc->num_participants;
+            int              i;
+
+            biscuit_collect_sorted_tids_single(idx, result,
+                                               &all_tids, &all_count,
+                                               needs_sorting);
+
+            pdesc->total_tids = (uint64_t) all_count;
+
+            if (all_count > 0 && np > 0)
+            {
+                /*
+                 * Divide total_tids into np roughly-equal slices.
+                 * base_size = floor(all_count / np)
+                 * remainder = all_count % np   (distributed to last slot)
+                 *
+                 * We give the last slot whatever is left so uneven divisions
+                 * never lose or duplicate TIDs.
+                 */
+                uint64_t base_size = (uint64_t) all_count / (uint64_t) np;
+                uint64_t cursor    = 0;
+
+                for (i = 0; i < np; i++)
+                {
+                    pdesc->slots[i].start = cursor;
+                    if (i < np - 1)
+                        cursor += base_size;
+                    else
+                        cursor  = (uint64_t) all_count; /* last gets remainder */
+                    pdesc->slots[i].end = cursor;
+                }
+            }
+            else
+            {
+                /* Empty result or no participants: zero all slots. */
+                for (i = 0; i < BISCUIT_MAX_PARALLEL_WORKERS + 1; i++)
+                    pdesc->slots[i].start = pdesc->slots[i].end = 0;
+            }
+
+            /*
+             * Full barrier: slot writes must be visible to all processes
+             * before initialized is set to 2.
+             */
+            pg_memory_barrier();
+            pg_atomic_write_u32(&pdesc->initialized, 2);
+
+            /* Free the full array — we'll re-evaluate per-process below. */
+            if (all_tids)
+                pfree(all_tids);
+        }
+        else
+        {
+            /*
+             * Loser: spin until the initializer sets initialized = 2.
+             * Use a 1 µs sleep to avoid burning a core; CHECK_FOR_INTERRUPTS
+             * so the backend remains cancellable during the wait.
+             */
+            while (pg_atomic_read_u32(&pdesc->initialized) != 2)
+            {
+                CHECK_FOR_INTERRUPTS();
+                pg_usleep(1);
+            }
+            pg_memory_barrier();    /* ensure slot reads see the initializer's writes */
+        }
+    }
+
+    /* ---------------------------------------------------------------
+     * Phase 2: every participant reads its own pre-computed slot.
+     *
+     * MyParallelWorkerNumber:
+     *   -1 → leader  → slot 0
+     *    N → worker N → slot N+1
+     * --------------------------------------------------------------- */
+    {
+        int      slot_idx;
+        uint64_t my_start;
+        uint64_t my_end;
+        int      my_count;
+
+        slot_idx = ParallelWorkerNumber + 1;   /* leader: -1+1=0, worker N: N+1 */
+
+        /* Clamp defensively — should never fire under normal operation. */
+        if (slot_idx < 0 || slot_idx >= pdesc->num_participants)
+        {
+            elog(WARNING,
+                 "biscuit: parallel slot index %d out of range [0,%d); "
+                 "returning empty result",
+                 slot_idx, pdesc->num_participants);
+            return;
+        }
+
+        my_start = pdesc->slots[slot_idx].start;
+        my_end   = pdesc->slots[slot_idx].end;
+        my_count = (int) (my_end - my_start);
+
+        if (my_count <= 0 || pdesc->total_tids == 0)
+            return;   /* empty result or nothing assigned to this participant */
+
+        /* ---------------------------------------------------------------
+         * Phase 3: evaluate the bitmap locally and return only our slice.
+         *
+         * Every process produces an identical sorted TID array (same index,
+         * same query, fully read-only).  We keep only [my_start, my_end)
+         * and immediately free the rest to avoid peak memory N× total_tids.
+         * --------------------------------------------------------------- */
+        {
+            ItemPointerData *all_tids  = NULL;
+            int              all_count = 0;
+            ItemPointerData *slice;
+
+            biscuit_collect_sorted_tids_single(idx, result,
+                                               &all_tids, &all_count,
+                                               needs_sorting);
+
+            if (all_count == 0 || all_tids == NULL)
+                return;
+
+            /*
+             * Sanity: if the bitmap count differs from what the initializer
+             * saw, something changed between evaluations.  Clamp to avoid
+             * an out-of-bounds read; log a warning so the operator knows.
+             */
+            if ((uint64_t) all_count != pdesc->total_tids)
+            {
+                elog(WARNING,
+                     "biscuit: parallel TID count mismatch: expected %llu, "
+                     "got %d; clamping slice",
+                     (unsigned long long) pdesc->total_tids, all_count);
+                if (my_end > (uint64_t) all_count)
+                    my_end = (uint64_t) all_count;
+                if (my_start >= my_end)
+                {
+                    pfree(all_tids);
+                    return;
+                }
+                my_count = (int) (my_end - my_start);
+            }
+
+            /* Copy the assigned slice into a fresh palloc buffer. */
+            slice = (ItemPointerData *)
+                        palloc(my_count * sizeof(ItemPointerData));
+            memcpy(slice, &all_tids[my_start],
+                   my_count * sizeof(ItemPointerData));
+
+            pfree(all_tids);    /* free the full local array immediately */
+
+            *out_tids  = slice;
+            *out_count = my_count;
+        }
+    }
 }
 
 /* ==================== PARALLEL WORKER ENTRY POINT ==================== */
 
 /*
- * biscuit_parallel_collect_worker — stub retained for dynamic loader
- * compatibility.
+ * biscuit_parallel_collect_worker
  *
- * RegisterParallelWorkerMain() records this symbol at extension load time.
- * Removing it would cause workers launched by an older leader to segfault on
- * lookup.  Since no caller in the current code base launches parallel workers
- * for TID collection, the body is a safe no-op.
+ * Registered via RegisterParallelWorkerMain() for dynamic-loader
+ * compatibility.  Body is a no-op stub; retained so symbol lookup on
+ * extension reload does not fail.
  */
 PGDLLEXPORT void
 biscuit_parallel_collect_worker(dsm_segment *seg, shm_toc *toc)
 {
     (void) seg;
     (void) toc;
+}
+
+/* ==================== PARALLEL WORKER HELPERS ==================== */
+
+/**
+ * biscuit_get_parallel_worker_count
+ *
+ * Returns the number of parallel workers active or requested for this index scan.
+ * Returns 0 if this is a single-threaded execution thread.
+ */
+int
+biscuit_get_parallel_worker_count(IndexScanDesc scan)
+{
+    BiscuitParallelScanDesc *pdesc;
+
+    if (scan == NULL || scan->parallel_scan == NULL)
+        return 0;
+
+    pdesc = (BiscuitParallelScanDesc *)
+                OffsetToPointer(scan->parallel_scan,
+                                scan->parallel_scan->ps_offset_am);
+
+    return (pdesc->num_participants > 1) ? pdesc->num_participants - 1 : 2;
 }
 
 /* ==================== SCAN HELPERS ==================== */
@@ -337,81 +567,68 @@ biscuit_is_aggregate_query(IndexScanDesc scan)
 /*
  * biscuit_estimateparallelscan
  *
- * Returns the number of bytes that must be reserved in the parallel DSM
- * segment for BiscuitParallelScanDesc.  The executor calls this once during
- * parallel query planning before the segment is created.
- *
- * We return the exact sizeof() so the executor passes a correctly-sized
- * pointer to biscuit_initparallelscan().
+ * Returns sizeof(BiscuitParallelScanDesc) so the executor reserves exactly
+ * the right amount of DSM space.
  */
 Size
 biscuit_estimateparallelscan(Relation indexRelation, int nworkers, int nchunks)
 {
     (void) indexRelation;
-    (void) nworkers;
     (void) nchunks;
+    biscuit_planned_nworkers = nworkers;   /* save for initparallelscan */
     return sizeof(BiscuitParallelScanDesc);
 }
 
 /*
  * biscuit_initparallelscan
  *
- * Called by the parallel leader after the DSM segment has been allocated.
- * @target must point to at least sizeof(BiscuitParallelScanDesc) bytes of
- * DSM-backed memory.
+ * Called once by the leader after the DSM segment is allocated.
+ * Zeroes the descriptor, records num_participants, and sets initialized = 0
+ * so the first rescan triggers partition computation.
  *
- * We memset the descriptor to zero first so that every byte is defined,
- * then initialise next_chunk atomically to 0.  total_tids, total_chunks,
- * and chunk_size are set to their default/sentinel values here; callers
- * (scan.c, or the first worker entering biscuit_parallel_collect_chunk)
- * fill in the real counts once the bitmap result is known.
+ * num_participants is inferred as the number of active workers + 1 (leader).
+ * PostgreSQL does not pass nworkers here, so we derive it from
+ * ParallelWorkerNumber which the leader can read as 0 workers launched
+ * at this point (still during init).  Instead we store 0 and let
+ * biscuit_collect_sorted_tids_parallel() populate it from
+ * pdesc->num_participants.
  *
- * Design constraint: workers must NEVER write to shared state other than
- * through the atomic next_chunk counter.  All other fields are read-only
- * after this function returns.
+ * NOTE: nworkers is NOT available in this callback.  We therefore set
+ * num_participants to 0 here and resolve it lazily at the first
+ * biscuit_collect_sorted_tids_parallel() call using
+ * scan->parallel_scan->ps_nworkers + 1.  biscuit_rescan() passes this
+ * through the pdesc pointer which it derives from scan->parallel_scan.
+ * The caller in biscuit_scan.c sets pdesc->num_participants after this
+ * function returns.
  */
 void
 biscuit_initparallelscan(void *target)
 {
     BiscuitParallelScanDesc *pdesc = (BiscuitParallelScanDesc *) target;
-
-    /* Zero the entire struct first so padding bytes are well-defined. */
     memset(pdesc, 0, sizeof(BiscuitParallelScanDesc));
+    pg_atomic_init_u32(&pdesc->initialized, 0);
 
     /*
-     * Initialise the atomic counter.  pg_atomic_init_u64() must be called
-     * exactly once, in the leader, before any worker reads the counter.
+     * nworkers is unavailable here directly, but estimateparallelscan
+     * was called in the same process immediately before this.
+     * +1 for the leader.
      */
-    pg_atomic_init_u64(&pdesc->next_chunk, 0);
-
-    /*
-     * Set chunk_size to the default.  total_tids and total_chunks are left
-     * at 0; they will be populated by the caller (typically biscuit_rescan /
-     * biscuit_beginscan) once the result bitmap has been evaluated and the
-     * total TID count is known.
-     */
-    pdesc->chunk_size   = BISCUIT_PARALLEL_CHUNK_SIZE_DEFAULT;
-    pdesc->total_tids   = 0;
-    pdesc->total_chunks = 0;
+    pdesc->num_participants = biscuit_planned_nworkers + 1;
+    // biscuit_planned_nworkers = 0;   /* reset defensively */
+    elog(DEBUG1, "Initiated parallel scan. Parallel workers: %d",pdesc->num_participants);
 }
 
 /*
  * biscuit_parallelrescan
  *
- * AM callback invoked when a parallel scan must be rewound (e.g. a rescan
- * inside a Materialize node).  Resets next_chunk to 0 atomically so that all
- * workers restart from the first chunk.  The read-only fields (total_chunks,
- * chunk_size, total_tids) remain unchanged because the underlying index data
- * has not changed.
- *
- * pg_atomic_write_u64() provides a sequentially-consistent store on all
- * platforms supported by PostgreSQL's port/atomics layer.  No LWLocks or
- * spinlocks are required.
+ * Resets the descriptor for a fresh scan (e.g. Materialize node rewind).
+ * Clears initialized and all slots so the next rescan re-partitions.
  */
 void
 biscuit_parallelrescan(IndexScanDesc scan)
 {
     BiscuitParallelScanDesc *pdesc;
+    int                      i;
 
     if (scan->parallel_scan == NULL)
         return;
@@ -420,172 +637,11 @@ biscuit_parallelrescan(IndexScanDesc scan)
                 OffsetToPointer(scan->parallel_scan,
                                 scan->parallel_scan->ps_offset_am);
 
-    pg_atomic_write_u64(&pdesc->next_chunk, 0);
-}
+    /* Clear all slots and reset the initialized flag to 0. */
+    pdesc->total_tids = 0;
+    for (i = 0; i < BISCUIT_MAX_PARALLEL_WORKERS + 1; i++)
+        pdesc->slots[i].start = pdesc->slots[i].end = 0;
 
-/* ==================== PARALLEL WORKER HELPERS ==================== */
-
-/*
- * biscuit_claim_next_chunk
- *
- * Atomically increments next_chunk and returns the range of TID indices the
- * caller now owns exclusively.
- *
- * Returns true  → *chunk_start..*chunk_end-1 (exclusive upper) is valid work.
- * Returns false → all chunks have been claimed; caller should exit.
- *
- * The fetch-add is the ONLY write to shared memory performed by workers.
- * chunk_start = claimed_chunk * chunk_size
- * chunk_end   = min(chunk_start + chunk_size, total_tids)
- */
-bool
-biscuit_claim_next_chunk(BiscuitParallelScanDesc *pdesc,
-                         uint64_t *chunk_start,
-                         uint64_t *chunk_end)
-{
-    uint64_t claimed;
-
-    Assert(pdesc != NULL);
-
-    /* Atomically claim one chunk slot.  Sequentially consistent. */
-    claimed = pg_atomic_fetch_add_u64(&pdesc->next_chunk, 1);
-
-    if (claimed >= pdesc->total_chunks)
-        return false;   /* no work left */
-
-    *chunk_start = claimed * (uint64_t) pdesc->chunk_size;
-    *chunk_end   = *chunk_start + (uint64_t) pdesc->chunk_size;
-
-    /* Clamp to the actual TID count to avoid over-reading. */
-    if (*chunk_end > pdesc->total_tids)
-        *chunk_end = pdesc->total_tids;
-
-    return true;
-}
-
-/*
- * biscuit_parallel_collect_chunk
- *
- * Worker-side TID collection loop.
- *
- * Parameters
- * ----------
- * idx        – read-only pointer to the in-memory BiscuitIndex.
- * pdesc      – pointer to the shared BiscuitParallelScanDesc (DSM).
- *              The only write is through biscuit_claim_next_chunk().
- * all_tids   – pointer to the full, pre-sorted TID array produced by the
- *              leader (stored read-only in the worker's address space).
- * total_tids – length of all_tids[].
- * out_tids   – (output) worker-local palloc'd TID array.
- * out_count  – (output) number of valid TIDs written into *out_tids.
- *
- * Algorithm
- * ---------
- * 1. Claim a chunk via biscuit_claim_next_chunk().
- * 2. Copy the corresponding slice of all_tids[] into a worker-local buffer.
- *    The buffer is grown with repalloc() as new chunks are claimed, avoiding
- *    per-chunk palloc overhead.
- * 3. Repeat until no chunks remain.
- *
- * Shared-state invariant: workers never write to *pdesc except through the
- * atomic counter.  all_tids[] is read-only throughout.  *out_tids is
- * process-private and never shared.
- *
- * Note: when all_tids is NULL (total_tids == 0) the function returns
- * immediately with *out_tids = NULL and *out_count = 0.
- */
-void
-biscuit_parallel_collect_chunk(BiscuitIndex        *idx,
-                               BiscuitParallelScanDesc *pdesc,
-                               ItemPointerData     *all_tids,
-                               uint64_t             total_tids,
-                               ItemPointerData    **out_tids,
-                               int                 *out_count)
-{
-    ItemPointerData *local_buf   = NULL;
-    int              local_cap   = 0;
-    int              local_count = 0;
-
-    uint64_t chunk_start;
-    uint64_t chunk_end;
-
-    /* Guard against empty result sets. */
-    if (all_tids == NULL || total_tids == 0 || pdesc == NULL)
-    {
-        *out_tids  = NULL;
-        *out_count = 0;
-        return;
-    }
-
-    /*
-     * Estimate the local buffer size as one chunk to avoid the first
-     * repalloc in the common case where each worker processes exactly one
-     * chunk.  We grow on demand.
-     */
-    local_cap = (int) pdesc->chunk_size;
-    local_buf = (ItemPointerData *)
-                    palloc(local_cap * sizeof(ItemPointerData));
-
-    while (biscuit_claim_next_chunk(pdesc, &chunk_start, &chunk_end))
-    {
-        uint64_t slot;
-        int      count_in_chunk = (int) (chunk_end - chunk_start);
-
-        Assert(chunk_start < total_tids);
-        Assert(chunk_end  <= total_tids);
-        Assert(count_in_chunk > 0);
-
-        /* Grow the local buffer if necessary. */
-        if (local_count + count_in_chunk > local_cap)
-        {
-            /*
-             * Double (or grow to fit) to keep amortised cost O(1) per TID.
-             * We never exceed INT_MAX entries because total_tids is bounded
-             * by idx->num_records which is an int.
-             */
-            while (local_cap < local_count + count_in_chunk)
-            {
-                local_cap *= 2;
-                if (local_cap < 0) /* overflow guard */
-                {
-                    elog(ERROR, "biscuit: parallel TID buffer overflow");
-                }
-            }
-            local_buf = (ItemPointerData *)
-                            repalloc(local_buf,
-                                     local_cap * sizeof(ItemPointerData));
-        }
-
-        /*
-         * Bulk copy the TID slice.  all_tids[] is read-only; we write only
-         * into our process-private local_buf[].
-         */
-        for (slot = chunk_start; slot < chunk_end; slot++)
-        {
-            /*
-             * Prefetch the next slot's data into L2 to hide latency when
-             * chunks are large.  The target is the TID entry that follows
-             * PREFETCH_DISTANCE positions in the chunk.
-             */
-            if (slot + PREFETCH_DISTANCE < chunk_end)
-                __builtin_prefetch(&all_tids[slot + PREFETCH_DISTANCE], 0, 1);
-
-            ItemPointerCopy(&all_tids[slot],
-                            &local_buf[local_count]);
-            local_count++;
-        }
-
-        CHECK_FOR_INTERRUPTS();
-    }
-
-    if (local_count == 0)
-    {
-        pfree(local_buf);
-        *out_tids  = NULL;
-        *out_count = 0;
-        return;
-    }
-
-    *out_tids  = local_buf;
-    *out_count = local_count;
+    pg_memory_barrier();
+    pg_atomic_write_u32(&pdesc->initialized, 0);
 }

--- a/src/biscuit_tid.h
+++ b/src/biscuit_tid.h
@@ -27,20 +27,13 @@ extern void biscuit_collect_sorted_tids_parallel(BiscuitIndex *idx,
                                                  bool needs_sorting);
 
 /*
- * Unified entry point: chooses parallel vs. single-threaded automatically
- * and supports an optional LIMIT hint (pass -1 for "no limit").
+ * Parallel worker entry point — registered via RegisterParallelWorkerMain()
+ * and also called directly by the leader process to participate as an extra
+ * worker.  The name string must match the one passed to CreateParallelContext.
  */
-extern void biscuit_collect_tids_optimized(BiscuitIndex *idx,
-                                           RoaringBitmap *result,
-                                           ItemPointerData **out_tids,
-                                           int *out_count,
-                                           bool needs_sorting,
-                                           int limit_hint);
+PGDLLEXPORT extern void biscuit_parallel_collect_worker(dsm_segment *seg, shm_toc *toc);
 
 /* Detect whether a scan is aggregate-only (no tuple fetch needed). */
 extern bool biscuit_is_aggregate_query(IndexScanDesc scan);
-
-/* Estimate a LIMIT hint from a scan descriptor (-1 = unknown). */
-extern int  biscuit_estimate_limit_hint(IndexScanDesc scan);
 
 #endif /* BISCUIT_TID_H */

--- a/src/biscuit_tid.h
+++ b/src/biscuit_tid.h
@@ -28,39 +28,89 @@
 /*
  * BiscuitParallelScanDesc
  *
- * Lives in the parallel query DSM segment, written once by
- * biscuit_initparallelscan() and read by every worker.  Workers advance
- * next_chunk atomically; all other fields are read-only after init.
+ * Lives in the parallel query DSM segment.  Carries the pre-computed
+ * per-participant TID partition table so each worker can self-identify and
+ * read its own disjoint [start, end) range without any runtime coordination.
  *
- * Layout rules:
- *   • next_chunk must be naturally aligned for pg_atomic_uint64 (8 bytes).
- *   • pad[] ensures the hot atomic word and the read-only fields do not share
- *     a cache line, eliminating false-sharing between workers.
- *   • sizeof(BiscuitParallelScanDesc) is returned by
- *     biscuit_estimateparallelscan() so the executor reserves exactly the
- *     right amount of DSM space.
+ * Parallel design — pre-partition, self-identify, local evaluate
+ * --------------------------------------------------------------
+ * PostgreSQL parallel workers are separate OS processes with disjoint virtual
+ * address spaces.  Only memory inside this DSM struct is shared.
+ *
+ * Key observations that drive the design:
+ *
+ *   A. The bitmap is read-only and deterministic: every process that evaluates
+ *      it against the same index with the same query produces an identical
+ *      sorted TID array.  So every participant can evaluate locally — no need
+ *      to ship the TID array across process boundaries.
+ *
+ *   B. MyParallelWorkerNumber is a process-local int set by PostgreSQL before
+ *      the first AM callback fires.  The leader has value -1; workers have
+ *      0, 1, 2, … in launch order.  This gives each participant a stable,
+ *      unique identity.
+ *
+ *   C. The executor tells us the worker count at estimateparallelscan /
+ *      initparallelscan time, before any bitmap evaluation.
+ *
+ * Putting it together:
+ *
+ *   Init (biscuit_initparallelscan):
+ *     • Record num_participants = 1 (leader) + nworkers.
+ *     • Set initialized = 0.  All slot [start,end) pairs remain 0.
+ *
+ *   First rescan (any participant — whoever calls biscuit_rescan first):
+ *     • CAS initialized: 0 → 1.  Winner evaluates the bitmap, computes the
+ *       full sorted TID count, and fills slots[0..num_participants-1] with
+ *       pre-computed [start, end) ranges.  The last slot absorbs any remainder
+ *       so uneven divisions are handled correctly.  Then sets initialized = 2.
+ *     • All other participants spin on initialized until it reaches 2.
+ *       No per-TID coordination ever happens.
+ *
+ *   Each rescan:
+ *     • Participant reads MyParallelWorkerNumber → slot index
+ *         leader  (-1) → slot 0
+ *         worker N     → slot N+1
+ *     • Evaluates bitmap locally, returns only tids[slots[i].start .. slots[i].end).
+ *
+ *   Rescan (biscuit_parallelrescan):
+ *     • Reset initialized = 0 and clear all slots so the next scan re-partitions.
+ *
+ * No atomic chunk counter.  No spin on chunk claims.  No false-sharing.
+ * The only shared writes are the one-time partition computation.
  */
-#define BISCUIT_PARALLEL_CHUNK_SIZE_DEFAULT  1024
 
+/* Maximum participants (1 leader + up to this many workers). */
+#define BISCUIT_MAX_PARALLEL_WORKERS  64
+
+/*
+ * BiscuitWorkerSlot — the TID index range assigned to one participant.
+ * start is inclusive, end is exclusive.  Both are indices into the local
+ * sorted TID array (identical across all processes for a given scan).
+ */
+typedef struct BiscuitWorkerSlot
+{
+    uint64_t    start;      /* first TID index for this participant */
+    uint64_t    end;        /* one past the last TID index          */
+} BiscuitWorkerSlot;
+
+/*
+ * initialized state values
+ *   0 – partition table not yet computed.
+ *   1 – computation in progress (one participant holds the lock).
+ *   2 – partition table ready; all participants may proceed.
+ */
 typedef struct BiscuitParallelScanDesc
 {
-    /*
-     * Atomically incremented by each worker to claim the next chunk index.
-     * A worker that reads a value >= total_chunks finds no work and exits.
-     * Only pg_atomic_fetch_add_u64() is used — no spinlocks, no LWLocks.
-     */
-    pg_atomic_uint64  next_chunk;       /* next chunk index to claim         */
-
-    uint64_t          total_chunks;     /* ceil(total_tids / chunk_size)     */
-    uint32_t          chunk_size;       /* TIDs per chunk (default 1024)     */
-    uint64_t          total_tids;       /* total live TIDs in this scan      */
+    pg_atomic_uint32  initialized;      /* 0=uninit, 1=computing, 2=ready    */
+    int32             num_participants; /* leader + workers                  */
+    uint64_t          total_tids;       /* filled in by the initializer      */
 
     /*
-     * Padding to a full cache line (64 bytes) so that next_chunk (written
-     * by every worker) and the read-only fields above do not share a line.
-     * Adjust if the fields above grow.
+     * Per-participant TID ranges.  Slot 0 is always the leader; slot i+1
+     * belongs to background worker i (MyParallelWorkerNumber == i).
+     * The last slot's end is clamped to total_tids to absorb any remainder.
      */
-    char              pad[64];
+    BiscuitWorkerSlot slots[BISCUIT_MAX_PARALLEL_WORKERS + 1];
 } BiscuitParallelScanDesc;
 
 /* Sort an array of TIDs for sequential heap access. */
@@ -73,25 +123,55 @@ extern void biscuit_collect_sorted_tids_single(BiscuitIndex *idx,
                                                int *out_count,
                                                bool needs_sorting);
 
+
 /*
- * ABI-compatibility shim — delegates to biscuit_collect_sorted_tids_single().
- * The DSM-based parallel implementation has been removed; callers that
- * previously used this entry point continue to work without modification.
+ * biscuit_collect_sorted_tids_parallel
+ *
+ * Parallel-aware TID collection.  Called by EVERY participant (leader and
+ * background workers) from biscuit_rescan() whenever scan->parallel_scan
+ * is non-NULL.
+ *
+ * Algorithm
+ * ---------
+ * 1. The first participant to arrive CASes pdesc->initialized from 0 → 1,
+ *    evaluates the bitmap, computes the full sorted TID count, divides it
+ *    evenly into pdesc->num_participants slices, writes each [start, end)
+ *    into pdesc->slots[], then sets initialized = 2.  The last slot absorbs
+ *    any remainder so uneven divisions are always correct.
+ *
+ * 2. All other participants spin on initialized until it reaches 2 (with
+ *    CHECK_FOR_INTERRUPTS and a 1 µs sleep to avoid burning a core).
+ *
+ * 3. Every participant reads its own slot using its stable worker identity:
+ *       leader  (MyParallelWorkerNumber == -1) → slot 0
+ *       worker N (MyParallelWorkerNumber ==  N) → slot N+1
+ *
+ * 4. Each participant evaluates the bitmap locally (identical result for all
+ *    — deterministic read-only operation) and returns only the TIDs in its
+ *    assigned [start, end) range.
+ *
+ * No per-TID atomic operations.  No chunk claiming races.  The Gather node
+ * assembles exactly one copy of the full result from the disjoint per-process
+ * slices.
+ *
+ * When pdesc is NULL the function is identical to
+ * biscuit_collect_sorted_tids_single() (non-parallel path).
  */
 extern void biscuit_collect_sorted_tids_parallel(BiscuitIndex *idx,
-                                                 RoaringBitmap *result,
-                                                 ItemPointerData **out_tids,
-                                                 int *out_count,
-                                                 bool needs_sorting);
+                                                  RoaringBitmap *result,
+                                                  BiscuitParallelScanDesc *pdesc,
+                                                  ItemPointerData **out_tids,
+                                                  int *out_count,
+                                                  bool needs_sorting);
 
 /*
  * Parallel worker entry point — registered via RegisterParallelWorkerMain()
- * for dynamic-loader compatibility.  No longer launches real workers; body
- * is a no-op stub.  The name string must match the one used in any existing
- * CreateParallelContext calls to avoid lookup failures on extension reload.
+ * for dynamic-loader compatibility.  Body is a no-op stub; retained so
+ * symbol lookup on extension reload does not fail.
  */
 PGDLLEXPORT extern void biscuit_parallel_collect_worker(dsm_segment *seg, shm_toc *toc);
 
+PGDLLIMPORT extern int ParallelWorkerNumber;
 /* Detect whether a scan is aggregate-only (no tuple fetch needed). */
 extern bool biscuit_is_aggregate_query(IndexScanDesc scan);
 
@@ -100,67 +180,35 @@ extern bool biscuit_is_aggregate_query(IndexScanDesc scan);
 /*
  * biscuit_estimateparallelscan
  *
- * AM callback: returns the number of bytes the executor must reserve in the
- * parallel DSM segment for the BiscuitParallelScanDesc.  Called once by the
- * leader before the segment is created.
+ * AM callback: returns sizeof(BiscuitParallelScanDesc) so the executor
+ * reserves exactly the right amount of DSM space.  nworkers is also stored
+ * so biscuit_initparallelscan can record num_participants.
  */
 extern Size biscuit_estimateparallelscan(Relation indexRelation, int nworkers, int nchunks);
 
 /*
  * biscuit_initparallelscan
  *
- * AM callback: called by the leader after the DSM segment has been created.
- * Initialises next_chunk to 0 and fills in the read-only fields.
- * @target  pointer to the BiscuitParallelScanDesc inside the DSM segment.
- *
- * Note: total_tids and chunk_size cannot be known at init time (the scan has
- * not yet been executed); they are set to sentinel values here and populated
- * by the first worker that enters biscuit_parallel_collect_chunk().  Only
- * next_chunk must be initialised to 0 at this stage so the executor can
- * safely call biscuit_parallelrescan() later.
+ * AM callback: zeroes the descriptor and records num_participants so the
+ * partition table can be sized correctly at first rescan.  Sets
+ * initialized = 0 (not yet computed).
  */
 extern void biscuit_initparallelscan(void *target);
 
 /*
  * biscuit_parallelrescan
  *
- * AM callback: resets next_chunk to 0 so the same DSM segment can be reused
- * for a rescan without re-allocating shared memory.
+ * AM callback: resets initialized = 0 and clears all slots so the next
+ * rescan re-partitions from scratch (handles Materialize node rewinds).
  */
 extern void biscuit_parallelrescan(IndexScanDesc scan);
 
-/* ==================== PARALLEL WORKER HELPERS ==================== */
-
-/*
- * biscuit_claim_next_chunk
- *
- * Atomically claims the next available chunk from the shared descriptor.
- * Returns true and sets *chunk_start / *chunk_end to the TID range the
- * caller owns.  Returns false when all chunks have been claimed.
- *
- * Only pg_atomic_fetch_add_u64() is used; no locks of any kind.
+/**
+ * biscuit_get_parallel_worker_count
+ * * Returns the number of parallel workers planned for this index scan.
+ * Returns 0 if this is a single-threaded execution or if parallel 
+ * scan state is not initialized.
  */
-extern bool biscuit_claim_next_chunk(BiscuitParallelScanDesc *pdesc,
-                                     uint64_t *chunk_start,
-                                     uint64_t *chunk_end);
-
-/*
- * biscuit_parallel_collect_chunk
- *
- * Worker loop.  Repeatedly calls biscuit_claim_next_chunk() and copies the
- * corresponding TID slice from all_tids (a worker-visible, read-only snapshot
- * of the full sorted TID array) into a worker-local palloc'd buffer pointed
- * to by *out_tids / *out_count.  The buffer is grown with repalloc() as
- * additional chunks are claimed.
- *
- * Workers never write to shared state other than through the atomic counter
- * inside BiscuitParallelScanDesc.
- */
-extern void biscuit_parallel_collect_chunk(BiscuitIndex *idx,
-                                           BiscuitParallelScanDesc *pdesc,
-                                           ItemPointerData *all_tids,
-                                           uint64_t total_tids,
-                                           ItemPointerData **out_tids,
-                                           int *out_count);
+extern int biscuit_get_parallel_worker_count(IndexScanDesc scan);
 
 #endif /* BISCUIT_TID_H */

--- a/src/biscuit_tid.h
+++ b/src/biscuit_tid.h
@@ -1,6 +1,20 @@
 /*
  * biscuit_tid.h
- * TID sorting (radix + qsort) and parallel TID-collection declarations.
+ * TID sorting (radix + qsort) and TID-collection declarations.
+ *
+ * TIDCollectionWorker and biscuit_collect_tids_worker() have been removed:
+ * the parallel collection path that required them was replaced by a
+ * single-threaded implementation that eliminated a 3× performance regression.
+ *
+ * Parallel index scan support (amparallelrescan infrastructure):
+ *   BiscuitParallelScanDesc  – shared-memory descriptor placed in the
+ *                              parallel query DSM segment by aminitparallelscan.
+ *   biscuit_estimateparallelscan() – reports its size to the executor.
+ *   biscuit_initparallelscan()     – initialises the atomic chunk counter.
+ *   biscuit_parallelrescan()       – resets the counter for a new scan.
+ *   biscuit_claim_next_chunk()     – atomically claims the next chunk slot.
+ *   biscuit_parallel_collect_chunk() – worker loop; writes only into a
+ *                                      worker-local palloc'd buffer.
  */
 
 #ifndef BISCUIT_TID_H
@@ -8,6 +22,46 @@
 
 #include "biscuit_common.h"
 #include "biscuit_bitmap.h"
+
+/* ==================== PARALLEL SCAN DESCRIPTOR ==================== */
+
+/*
+ * BiscuitParallelScanDesc
+ *
+ * Lives in the parallel query DSM segment, written once by
+ * biscuit_initparallelscan() and read by every worker.  Workers advance
+ * next_chunk atomically; all other fields are read-only after init.
+ *
+ * Layout rules:
+ *   • next_chunk must be naturally aligned for pg_atomic_uint64 (8 bytes).
+ *   • pad[] ensures the hot atomic word and the read-only fields do not share
+ *     a cache line, eliminating false-sharing between workers.
+ *   • sizeof(BiscuitParallelScanDesc) is returned by
+ *     biscuit_estimateparallelscan() so the executor reserves exactly the
+ *     right amount of DSM space.
+ */
+#define BISCUIT_PARALLEL_CHUNK_SIZE_DEFAULT  1024
+
+typedef struct BiscuitParallelScanDesc
+{
+    /*
+     * Atomically incremented by each worker to claim the next chunk index.
+     * A worker that reads a value >= total_chunks finds no work and exits.
+     * Only pg_atomic_fetch_add_u64() is used — no spinlocks, no LWLocks.
+     */
+    pg_atomic_uint64  next_chunk;       /* next chunk index to claim         */
+
+    uint64_t          total_chunks;     /* ceil(total_tids / chunk_size)     */
+    uint32_t          chunk_size;       /* TIDs per chunk (default 1024)     */
+    uint64_t          total_tids;       /* total live TIDs in this scan      */
+
+    /*
+     * Padding to a full cache line (64 bytes) so that next_chunk (written
+     * by every worker) and the read-only fields above do not share a line.
+     * Adjust if the fields above grow.
+     */
+    char              pad[64];
+} BiscuitParallelScanDesc;
 
 /* Sort an array of TIDs for sequential heap access. */
 extern void biscuit_sort_tids_by_block(ItemPointerData *tids, int count);
@@ -19,7 +73,11 @@ extern void biscuit_collect_sorted_tids_single(BiscuitIndex *idx,
                                                int *out_count,
                                                bool needs_sorting);
 
-/* Parallel TID collection for large result sets. */
+/*
+ * ABI-compatibility shim — delegates to biscuit_collect_sorted_tids_single().
+ * The DSM-based parallel implementation has been removed; callers that
+ * previously used this entry point continue to work without modification.
+ */
 extern void biscuit_collect_sorted_tids_parallel(BiscuitIndex *idx,
                                                  RoaringBitmap *result,
                                                  ItemPointerData **out_tids,
@@ -28,12 +86,81 @@ extern void biscuit_collect_sorted_tids_parallel(BiscuitIndex *idx,
 
 /*
  * Parallel worker entry point — registered via RegisterParallelWorkerMain()
- * and also called directly by the leader process to participate as an extra
- * worker.  The name string must match the one passed to CreateParallelContext.
+ * for dynamic-loader compatibility.  No longer launches real workers; body
+ * is a no-op stub.  The name string must match the one used in any existing
+ * CreateParallelContext calls to avoid lookup failures on extension reload.
  */
 PGDLLEXPORT extern void biscuit_parallel_collect_worker(dsm_segment *seg, shm_toc *toc);
 
 /* Detect whether a scan is aggregate-only (no tuple fetch needed). */
 extern bool biscuit_is_aggregate_query(IndexScanDesc scan);
+
+/* ==================== PARALLEL AM CALLBACKS ==================== */
+
+/*
+ * biscuit_estimateparallelscan
+ *
+ * AM callback: returns the number of bytes the executor must reserve in the
+ * parallel DSM segment for the BiscuitParallelScanDesc.  Called once by the
+ * leader before the segment is created.
+ */
+extern Size biscuit_estimateparallelscan(Relation indexRelation, int nworkers, int nchunks);
+
+/*
+ * biscuit_initparallelscan
+ *
+ * AM callback: called by the leader after the DSM segment has been created.
+ * Initialises next_chunk to 0 and fills in the read-only fields.
+ * @target  pointer to the BiscuitParallelScanDesc inside the DSM segment.
+ *
+ * Note: total_tids and chunk_size cannot be known at init time (the scan has
+ * not yet been executed); they are set to sentinel values here and populated
+ * by the first worker that enters biscuit_parallel_collect_chunk().  Only
+ * next_chunk must be initialised to 0 at this stage so the executor can
+ * safely call biscuit_parallelrescan() later.
+ */
+extern void biscuit_initparallelscan(void *target);
+
+/*
+ * biscuit_parallelrescan
+ *
+ * AM callback: resets next_chunk to 0 so the same DSM segment can be reused
+ * for a rescan without re-allocating shared memory.
+ */
+extern void biscuit_parallelrescan(IndexScanDesc scan);
+
+/* ==================== PARALLEL WORKER HELPERS ==================== */
+
+/*
+ * biscuit_claim_next_chunk
+ *
+ * Atomically claims the next available chunk from the shared descriptor.
+ * Returns true and sets *chunk_start / *chunk_end to the TID range the
+ * caller owns.  Returns false when all chunks have been claimed.
+ *
+ * Only pg_atomic_fetch_add_u64() is used; no locks of any kind.
+ */
+extern bool biscuit_claim_next_chunk(BiscuitParallelScanDesc *pdesc,
+                                     uint64_t *chunk_start,
+                                     uint64_t *chunk_end);
+
+/*
+ * biscuit_parallel_collect_chunk
+ *
+ * Worker loop.  Repeatedly calls biscuit_claim_next_chunk() and copies the
+ * corresponding TID slice from all_tids (a worker-visible, read-only snapshot
+ * of the full sorted TID array) into a worker-local palloc'd buffer pointed
+ * to by *out_tids / *out_count.  The buffer is grown with repalloc() as
+ * additional chunks are claimed.
+ *
+ * Workers never write to shared state other than through the atomic counter
+ * inside BiscuitParallelScanDesc.
+ */
+extern void biscuit_parallel_collect_chunk(BiscuitIndex *idx,
+                                           BiscuitParallelScanDesc *pdesc,
+                                           ItemPointerData *all_tids,
+                                           uint64_t total_tids,
+                                           ItemPointerData **out_tids,
+                                           int *out_count);
 
 #endif /* BISCUIT_TID_H */


### PR DESCRIPTION
Merge branch `parallelscan-hook`

Release Biscuit 2.3.0 "Bagel" with parallel index scan support, improved LIKE/ILIKE matching, and extensive index stability fixes.

Highlights:

* Add PostgreSQL parallel index scan support for Gather plans
* Introduce pre-lowercased multi-column caches to accelerate ILIKE queries
* Replace fallback pattern matching with correct UTF-8-aware LIKE/ILIKE handling
* Consolidate TID collection into a unified parallel-aware implementation
* Eliminate per-row allocations during ILIKE fallback scans

Fixes:

* Resolve SELECT → INSERT crashes on partially loaded indexes
* Prevent stale session caches from hiding newly inserted rows
* Update multi-column length bitmaps during inserts
* Fix cache growth initialization bugs that could cause instability
* Preserve in-memory changes across relcache invalidations
* Prevent planner selection for unqualified scans
* Correct single-column LIKE/ILIKE query dispatch
* Ensure preload completion transitions indexes to the warm state
* Reduce cache update overhead during inserts

Internal changes:

* Rework parallel scan infrastructure around shared-memory descriptors
* Add support for PostgreSQL parallel AM callbacks
* Remove ineffective LIMIT-tracking logic

Bump Biscuit version to 2.3.0 ("Bagel").
